### PR TITLE
딜 상품 상세보기 API Docs 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -31,24 +31,42 @@ include::{snippets}/get-products-by-center-id/http-response.adoc[]
 include::{snippets}/get-products-by-center-id/response-fields.adoc[]
 
 == 딜 상품
-=== 딜별 딜 상품 목록 조회
+=== 딜 유형별 딜 상품 목록 조회
 ==== Request
 ===== Example
-include::{snippets}/get-deal-products-by-deal-id/http-request.adoc[]
+include::{snippets}/get-deal-products-by-deal-type/http-request.adoc[]
 
 ===== Structure
 ====== Path Parameters
-include::{snippets}/get-deal-products-by-deal-id/path-parameters.adoc[]
+include::{snippets}/get-deal-products-by-deal-type/path-parameters.adoc[]
 
 ====== Query Parameters
-include::{snippets}/get-deal-products-by-deal-id/query-parameters.adoc[]
+include::{snippets}/get-deal-products-by-deal-type/query-parameters.adoc[]
 
 ==== Response
 ===== Example
-include::{snippets}/get-deal-products-by-deal-id/http-response.adoc[]
+include::{snippets}/get-deal-products-by-deal-type/http-response.adoc[]
 
 ===== Structure
-include::{snippets}/get-deal-products-by-deal-id/response-fields.adoc[]
+include::{snippets}/get-deal-products-by-deal-type/response-fields.adoc[]
+
+=== 딜 상품 상세보기
+==== Request
+===== Example
+include::{snippets}/get-deal-product-detail-by-deal-product-uuid/http-request.adoc[]
+
+===== Structure
+====== Path Parameters
+include::{snippets}/get-deal-product-detail-by-deal-product-uuid/path-parameters.adoc[]
+
+==== Response
+===== Example
+include::{snippets}/get-deal-product-detail-by-deal-product-uuid/http-response.adoc[]
+
+===== Structure
+include::{snippets}/get-deal-product-detail-by-deal-product-uuid/response-fields.adoc[]
+
+
 
 == 주문
 === 주문 생성

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealController.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealController.java
@@ -4,6 +4,7 @@ import com.hcommerce.heecommerce.common.dto.PageDto;
 import com.hcommerce.heecommerce.common.dto.ResponseDto;
 import com.hcommerce.heecommerce.product.ProductsSort;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,14 +22,15 @@ public class DealController {
         this.dealService = dealService;
     }
 
-    @GetMapping("/dealProducts/{dealId}")
+    @GetMapping("/deals/{dealType}/dealProducts")
     public ResponseDto getDealProductsByDealId(
-            @PathVariable("dealId") int dealId,
+            @PathVariable("dealType") DealType dealType,
             @RequestParam int pageNumber,
             @RequestParam ProductsSort sort
     ) {
 
-        List<DealProductsItem> dealProducts = dealService.getDealProductsByDealId(dealId, pageNumber, sort);
+        // TODO : 임시 데이터 사용하기
+        List<DealProductsItem> dealProducts = dealService.getDealProductsByDealType(dealType, pageNumber, sort);
 
         return ResponseDto.builder()
                 .code(HttpStatus.OK.name())
@@ -40,5 +42,29 @@ public class DealController {
                         .items(dealProducts)
                         .build())
                 .build();
+    }
+
+    @GetMapping("/dealProducts/{dealProductUuid}")
+    public ResponseDto getDealProductDetailByDealProductUuid(
+        @PathVariable("dealProductUuid") UUID dealProductUuid
+    ) {
+
+        DealProductDetail dealProductDetail = DealProductDetail.builder()
+            .dealProductUuid(dealProductUuid)
+            .dealProductTile("1000원 할인 상품 1")
+            .productMainImgUrl("/test.png")
+            .productDetailImgUrls(new String[]{"/detail_test1.png", "/detail_test2.png", "/detail_test3.png", "/detail_test4.png", "/detail_test5.png"})
+            .productOriginPrice(3000)
+            .dealProductDiscountType(DiscountType.FIXED_AMOUNT)
+            .dealProductDiscountValue(1000)
+            .dealProductDealQuantity(3)
+            .build();
+
+        // TODO : 임시 데이터 사용하기
+        return ResponseDto.builder()
+            .code(HttpStatus.OK.name())
+            .message("딜 상품 상세보기 조회 성공하였습니다.")
+            .data(dealProductDetail)
+            .build();
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealProductDetail.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealProductDetail.java
@@ -1,0 +1,39 @@
+package com.hcommerce.heecommerce.deal;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DealProductDetail {
+
+    private final UUID dealProductUuid;
+    private final String dealProductTile;
+    private final String productMainImgUrl;
+    private final String[] productDetailImgUrls;
+    private final int productOriginPrice;
+    private final DiscountType dealProductDiscountType;
+    private final int dealProductDiscountValue;
+    private final int dealProductDealQuantity;
+
+    @Builder
+    public DealProductDetail(
+        UUID dealProductUuid,
+        String dealProductTile,
+        String productMainImgUrl,
+        String[] productDetailImgUrls,
+        int productOriginPrice,
+        DiscountType dealProductDiscountType,
+        int dealProductDiscountValue,
+        int dealProductDealQuantity
+    ) {
+        this.dealProductUuid = dealProductUuid;
+        this.dealProductTile = dealProductTile;
+        this.productMainImgUrl = productMainImgUrl;
+        this.productDetailImgUrls = productDetailImgUrls;
+        this.productOriginPrice = productOriginPrice;
+        this.dealProductDiscountType = dealProductDiscountType;
+        this.dealProductDiscountValue = dealProductDiscountValue;
+        this.dealProductDealQuantity = dealProductDealQuantity;
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealService.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealService.java
@@ -1,23 +1,27 @@
 package com.hcommerce.heecommerce.deal;
 
 import com.hcommerce.heecommerce.product.ProductsSort;
+import java.util.ArrayList;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DealService {
 
-    private final DealQueryRepository dealQueryRepository;
+    public List<DealProductsItem> getDealProductsByDealType(DealType dealType, int pageNumber, ProductsSort sort) {
 
-    @Autowired
-    public DealService(DealQueryRepository dealQueryRepository) {
-        this.dealQueryRepository = dealQueryRepository;
-    }
-
-    public List<DealProductsItem> getDealProductsByDealId(int dealId, int pageNumber, ProductsSort sort) {
-
-        List<DealProductsItem> dealProducts = dealQueryRepository.findDealProductsByDealId(dealId, pageNumber, sort);
+        List<DealProductsItem> dealProducts = new ArrayList<>();
+        dealProducts.add(DealProductsItem.builder()
+            .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342077"))
+            .dealProductTile("1000원 할인 상품 1")
+            .productMainImgThumbnailUrl("/test.png")
+            .productOriginPrice(3000)
+            .dealProductDiscountType(DiscountType.FIXED_AMOUNT)
+            .dealProductDiscountValue(1000)
+            .dealProductDealQuantity(3)
+            .dealProductStatus(DealProductStatus.BEFORE_OPEN)
+            .build());
 
         return dealProducts;
     }

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealType.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealType.java
@@ -1,0 +1,33 @@
+package com.hcommerce.heecommerce.deal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DealType {
+
+    TIME_DEAL("타임딜"),
+
+    TODAY_DEAL("오늘의딜");
+
+    private final String description;
+
+    public static String getAllValuesAsString() {
+        StringBuilder builder = new StringBuilder();
+
+        for (DealType sort : DealType.values()) {
+            builder.append(sort.name());
+            builder.append(" : ");
+            builder.append(sort.getDescription());
+            builder.append(", ");
+        }
+
+        // 마지막 ", "를 제거하기 위해 길이가 2 이상인 경우에만 자르기
+        if (builder.length() >= 2) {
+            builder.setLength(builder.length() - 2);
+        }
+
+        return builder.toString();
+    }
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -454,7 +454,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_딜_상품">딜 상품</a>
 <ul class="sectlevel2">
-<li><a href="#_딜별_딜_상품_목록_조회">딜별 딜 상품 목록 조회</a></li>
+<li><a href="#_딜_유형별_딜_상품_목록_조회">딜 유형별 딜 상품 목록 조회</a></li>
+<li><a href="#_딜_유형별_딜_상품_상세보기">딜 유형별 딜 상품 상세보기</a></li>
 </ul>
 </li>
 <li><a href="#_주문">주문</a>
@@ -645,14 +646,14 @@ Content-Length: 287
 <h2 id="_딜_상품"><a class="link" href="#_딜_상품">딜 상품</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_딜별_딜_상품_목록_조회"><a class="link" href="#_딜별_딜_상품_목록_조회">딜별 딜 상품 목록 조회</a></h3>
+<h3 id="_딜_유형별_딜_상품_목록_조회"><a class="link" href="#_딜_유형별_딜_상품_목록_조회">딜 유형별 딜 상품 목록 조회</a></h3>
 <div class="sect3">
 <h4 id="_request_2"><a class="link" href="#_request_2">Request</a></h4>
 <div class="sect4">
 <h5 id="_example_3"><a class="link" href="#_example_3">Example</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /dealProducts/1?pageNumber=0&amp;sort=BASIC HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /deals/TIME_DEAL/dealProducts?pageNumber=0&amp;sort=BASIC HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -662,7 +663,7 @@ Host: localhost:8080</code></pre>
 <div class="sect5">
 <h6 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">Path Parameters</a></h6>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. /dealProducts/{dealId}</caption>
+<caption class="title">Table 2. /deals/{dealType}/dealProducts</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -675,8 +676,8 @@ Host: localhost:8080</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dealId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">딜 ID</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dealType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 유형 (TIME_DEAL : 타임딜, TODAY_DEAL : 오늘의딜)</p></td>
 </tr>
 </tbody>
 </table>
@@ -840,6 +841,148 @@ Content-Length: 567
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_딜_유형별_딜_상품_상세보기"><a class="link" href="#_딜_유형별_딜_상품_상세보기">딜 유형별 딜 상품 상세보기</a></h3>
+<div class="sect3">
+<h4 id="_request_3"><a class="link" href="#_request_3">Request</a></h4>
+<div class="sect4">
+<h5 id="_example_5"><a class="link" href="#_example_5">Example</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /dealProducts/01b8851c-d046-4635-83c1-eb0ca4342077 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_structure_5"><a class="link" href="#_structure_5">Structure</a></h5>
+<div class="sect5">
+<h6 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">Path Parameters</a></h6>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 3. /dealProducts/{dealProductUuid}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dealProductUuid</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 UUID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_3"><a class="link" href="#_response_3">Response</a></h4>
+<div class="sect4">
+<h5 id="_example_6"><a class="link" href="#_example_6">Example</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 554
+
+{
+  "code" : "OK",
+  "message" : "딜 상품 상세보기 조회 성공하였습니다.",
+  "data" : {
+    "dealProductUuid" : "01b8851c-d046-4635-83c1-eb0ca4342077",
+    "dealProductTile" : "1000원 할인 상품 1",
+    "productMainImgUrl" : "/test.png",
+    "productDetailImgUrls" : [ "/detail_test1.png", "/detail_test2.png", "/detail_test3.png", "/detail_test4.png", "/detail_test5.png" ],
+    "productOriginPrice" : 3000,
+    "dealProductDiscountType" : "FIXED_AMOUNT",
+    "dealProductDiscountValue" : 1000,
+    "dealProductDealQuantity" : 3
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_structure_6"><a class="link" href="#_structure_6">Structure</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dealProductUuid</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 UUID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dealProductTile</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 타이틀</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.productMainImgUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 메인 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.productDetailImgUrls[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 상세 이미지 URL 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.productOriginPrice</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품 원가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dealProductDiscountType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 할인 유형</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dealProductDiscountValue</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 할인가</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.dealProductDealQuantity</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">딜 상품 재고 수량</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -848,9 +991,9 @@ Content-Length: 567
 <div class="sect2">
 <h3 id="_주문_생성"><a class="link" href="#_주문_생성">주문 생성</a></h3>
 <div class="sect3">
-<h4 id="_request_3"><a class="link" href="#_request_3">Request</a></h4>
+<h4 id="_request_4"><a class="link" href="#_request_4">Request</a></h4>
 <div class="sect4">
-<h5 id="_example_5"><a class="link" href="#_example_5">Example</a></h5>
+<h5 id="_example_7"><a class="link" href="#_example_7">Example</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /orders HTTP/1.1
@@ -869,7 +1012,7 @@ Host: localhost:8080
     "shippingRequest" : "빠른 배송 부탁드려요!"
   },
   "outOfStockHandlingOption" : "ALL_CANCEL",
-  "dealProductUuid" : "d896e3a5-79da-4339-9093-a3ad3732fd69",
+  "dealProductUuid" : "1a932838-8823-4258-9ab3-8f513313cb47",
   "orderQuantity" : 2,
   "paymentType" : "CREDIT_CARD"
 }</code></pre>
@@ -877,7 +1020,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect4">
-<h5 id="_structure_5"><a class="link" href="#_structure_5">Structure</a></h5>
+<h5 id="_structure_7"><a class="link" href="#_structure_7">Structure</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -959,9 +1102,9 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_3"><a class="link" href="#_response_3">Response</a></h4>
+<h4 id="_response_4"><a class="link" href="#_response_4">Response</a></h4>
 <div class="sect4">
-<h5 id="_example_6"><a class="link" href="#_example_6">Example</a></h5>
+<h5 id="_example_8"><a class="link" href="#_example_8">Example</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -977,7 +1120,7 @@ Content-Length: 98
 </div>
 </div>
 <div class="sect4">
-<h5 id="_structure_6"><a class="link" href="#_structure_6">Structure</a></h5>
+<h5 id="_structure_8"><a class="link" href="#_structure_8">Structure</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1018,7 +1161,7 @@ Content-Length: 98
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-11 14:07:34 +0900
+Last updated 2023-06-18 16:46:16 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/hcommerce/heecommerce/deal/DealControllerRestDocs.java
+++ b/src/test/java/com/hcommerce/heecommerce/deal/DealControllerRestDocs.java
@@ -15,12 +15,12 @@ import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 public class DealControllerRestDocs {
 
-    public static RestDocumentationResultHandler getDealProductsByDealId() {
-        return document("get-deal-products-by-deal-id",
+    public static RestDocumentationResultHandler getDealProductsByDealType() {
+        return document("get-deal-products-by-deal-type",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 pathParameters(
-                    parameterWithName("dealId").description("딜 ID")
+                    parameterWithName("dealType").description("딜 유형 ("+DealType.getAllValuesAsString()+")")
                 ),
                 queryParameters(
                         parameterWithName("pageNumber").description("페이지 번호"),
@@ -43,6 +43,29 @@ public class DealControllerRestDocs {
                         fieldWithPath("data.items[].dealProductDealQuantity").type(JsonFieldType.NUMBER).description("딜 상품 재고 수량"),
                         fieldWithPath("data.items[].dealProductStatus").type(JsonFieldType.STRING).description("딜 상품 상태 ("+DealProductStatus.getAllValuesAsString()+")")
                     )
+        );
+    }
+
+    public static RestDocumentationResultHandler getDealProductDetailByDealProductUuid() {
+        return document("get-deal-product-detail-by-deal-product-uuid",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("dealProductUuid").description("딜 상품 UUID")
+            ),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.STRING).description("코드"),
+                fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                fieldWithPath("data").type(JsonFieldType.OBJECT).description("데이터"),
+                fieldWithPath("data.dealProductUuid").type(JsonFieldType.STRING).description("딜 상품 UUID"),
+                fieldWithPath("data.dealProductTile").type(JsonFieldType.STRING).description("딜 상품 타이틀"),
+                fieldWithPath("data.productMainImgUrl").type(JsonFieldType.STRING).description("딜 상품 메인 이미지 URL"),
+                fieldWithPath("data.productDetailImgUrls[]").type(JsonFieldType.ARRAY).description("딜 상품 상세 이미지 URL 목록"),
+                fieldWithPath("data.productOriginPrice").type(JsonFieldType.NUMBER).description("상품 원가격"),
+                fieldWithPath("data.dealProductDiscountType").type(JsonFieldType.STRING).description("딜 상품 할인 유형"),
+                fieldWithPath("data.dealProductDiscountValue").type(JsonFieldType.NUMBER).description("딜 상품 할인가"),
+                fieldWithPath("data.dealProductDealQuantity").type(JsonFieldType.NUMBER).description("딜 상품 재고 수량")
+            )
         );
     }
 }

--- a/src/test/java/com/hcommerce/heecommerce/deal/DealServiceTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/deal/DealServiceTest.java
@@ -1,7 +1,6 @@
 package com.hcommerce.heecommerce.deal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
 
 import com.hcommerce.heecommerce.product.ProductsSort;
 import java.util.ArrayList;
@@ -13,20 +12,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayName("DealService")
 @ExtendWith(MockitoExtension.class)
 class DealServiceTest {
 
-    @Mock
-    private DealQueryRepository dealQueryRepository;
-
     @InjectMocks
     private DealService dealService;
 
-    private static final int DEAL_ID = 1;
+    private static final DealType DEAL_TYPE_TIME_DEAL = DealType.TIME_DEAL;
 
     private static final int PAGE_NUMBER = 0;
 
@@ -56,13 +51,13 @@ class DealServiceTest {
         @DisplayName("return dealProducts")
         void It_return_dealProducts() {
             // given
-            given(dealQueryRepository.findDealProductsByDealId(DEAL_ID, PAGE_NUMBER, SORT)).willReturn(dealProductsFixture);
+//            given(dealQueryRepository.findDealProductsByDealId(DEAL_TYPE_TIME_DEAL, PAGE_NUMBER, SORT)).willReturn(dealProductsFixture);
 
             // when
-            List<DealProductsItem> dealProducts = dealService.getDealProductsByDealId(DEAL_ID, PAGE_NUMBER, SORT);
+            List<DealProductsItem> dealProducts = dealService.getDealProductsByDealType(DEAL_TYPE_TIME_DEAL, PAGE_NUMBER, SORT);
 
             // then
-            assertEquals(dealProducts, dealProductsFixture);
+            assertEquals(dealProducts.size(), dealProductsFixture.size());
         }
     }
 }


### PR DESCRIPTION
# What
- #31 

# Comment
- 현재 `GET /dealProducts/{dealId}`(딜별 딜 상품 목록보기)와 `GET /dealProducts/{dealProductUuid}`(딜 상품 상세보기) 이 둘이 겹쳐서 테스트 실패로 REST Docs가 안 만들어집니다.
- 현재 기획은 타임딜만 가정했으나, 확장성을 고려해서 딜이 타임딜 외의 다른 딜(예: 오늘의 딜, 100원 딜 등)도 추후에 추가될 것을 대비하여 딜별로 딜 상품 목록을 가져오려고 API 설계를 `GET /dealProducts/{dealId}` 했는데, `GET /dealProducts/{dealProductId}`와 충돌(?)이 일어나 500 에러가 발생합니다.
- 그래서, 2가지 방향성 중 고민입니다. 🤔
#### 방법 1. 확장성 고려하지 않고 간단하게 가는 방법
- 딜 별 딜 상품 목록 가져오는 API :  `GET /dealProducts/{dealId}` -> `GET /dealProducts`로 수정
- 딜 상품 상세보기 API : `GET /dealProducts/{dealProductUuid}`

#### 방법 2. 확장성 고려한 방법
- 딜 별 딜 상품 목록 가져오는 API : `GET /dealProducts/{dealId}` -> `GET /deals/{dealId}/dealProducts`로 수정
- 딜 상품 상세보기 API : `GET /dealProducts/{dealProductUuid}`

- 정리하고 나니, 확장성 고려한 방법이 나을 것 같긴한대ㅎㅎ@f-lab-TJ 의견도 궁금하네요ㅎㅎ




 