### PR TITLE
`TimeDealProductSummary` -> `DealProductSummary` 네이밍 수정

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/deal/DealController.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealController.java
@@ -29,12 +29,12 @@ public class DealController {
             @RequestParam ProductsSort sort
     ) {
 
-        List<TimeDealProductSummary> dealProducts = dealService.getDealProductsByDealType(dealType, pageNumber, sort);
+        List<DealProductSummary> dealProducts = dealService.getDealProductsByDealType(dealType, pageNumber, sort);
 
         return ResponseDto.builder()
                 .code(HttpStatus.OK.name())
                 .message("딜 상품 목록 조회 성공하였습니다.")
-                .data(PageDto.<TimeDealProductSummary>builder()
+                .data(PageDto.<DealProductSummary>builder()
                         .pageNumber(0)
                         .pageSize(20)
                         .totalCount(dealProducts.size())

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealProductSummary.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealProductSummary.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class TimeDealProductSummary {
+public class DealProductSummary {
 
     private final UUID dealProductUuid;
     private final String dealProductTile;
@@ -22,7 +22,7 @@ public class TimeDealProductSummary {
     private final DealProductStatus dealProductStatus;
 
     @Builder
-    public TimeDealProductSummary(
+    public DealProductSummary(
         UUID dealProductUuid,
         String dealProductTile,
         String productMainImgThumbnailUrl,
@@ -42,8 +42,8 @@ public class TimeDealProductSummary {
         this.dealProductStatus = dealProductStatus;
     }
 
-    public static List<TimeDealProductSummary> sortDealProducts(List<TimeDealProductSummary> dealProducts, ProductsSort sort) {
-        List<TimeDealProductSummary> newDealProducts = new ArrayList<>(dealProducts);
+    public static List<DealProductSummary> sortDealProducts(List<DealProductSummary> dealProducts, ProductsSort sort) {
+        List<DealProductSummary> newDealProducts = new ArrayList<>(dealProducts);
 
         if(sort == ProductsSort.PRICE_ASC) {
             Collections.sort(newDealProducts, originPriceAscComparator);
@@ -58,9 +58,9 @@ public class TimeDealProductSummary {
         }
     }
 
-    private static Comparator<TimeDealProductSummary> originPriceAscComparator = new Comparator<TimeDealProductSummary>() {
+    private static Comparator<DealProductSummary> originPriceAscComparator = new Comparator<DealProductSummary>() {
         @Override
-        public int compare(TimeDealProductSummary o1, TimeDealProductSummary o2) {
+        public int compare(DealProductSummary o1, DealProductSummary o2) {
             return o1.getProductOriginPrice() - o2.getProductOriginPrice();
         }
     };

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealQueryRepository.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealQueryRepository.java
@@ -32,7 +32,7 @@ public class DealQueryRepository {
         this.redisHashRepository = redisHashRepository;
     }
 
-    public List<TimeDealProductSummary> getDealProductsByDealType(DealType dealType, int pageNumber, ProductsSort sort) {
+    public List<DealProductSummary> getDealProductsByDealType(DealType dealType, int pageNumber, ProductsSort sort) {
         // TODO : 삭제 예정 -> 테스트용 데이터 추가로 만듬
 //        init();
 
@@ -42,9 +42,9 @@ public class DealQueryRepository {
 
         List<TimeDealProduct> timeDealProducts = getDealProducts(dateForCurrentDealProducts, dealProductIds);
 
-        List<TimeDealProductSummary> timeDealProductSummaries = convertTimeDealProductToTimeDealProductSummary(timeDealProducts);
+        List<DealProductSummary> timeDealProductSummaries = convertTimeDealProductToTimeDealProductSummary(timeDealProducts);
 
-        List<TimeDealProductSummary> sortedDealProducts = TimeDealProductSummary.sortDealProducts(timeDealProductSummaries, sort);
+        List<DealProductSummary> sortedDealProducts = DealProductSummary.sortDealProducts(timeDealProductSummaries, sort);
 
         return sortedDealProducts;
     }
@@ -64,14 +64,14 @@ public class DealQueryRepository {
         return timeDealProductDetail;
     }
 
-    private List<TimeDealProductSummary> convertTimeDealProductToTimeDealProductSummary(List<TimeDealProduct> timeDealProducts) {
+    private List<DealProductSummary> convertTimeDealProductToTimeDealProductSummary(List<TimeDealProduct> timeDealProducts) {
 
-        List<TimeDealProductSummary> timeDealProductSummaries = new ArrayList<>();
+        List<DealProductSummary> timeDealProductSummaries = new ArrayList<>();
 
         for (int i = 0; i < timeDealProducts.size(); i++) {
             TimeDealProduct timeDealProduct = timeDealProducts.get(i);
 
-            TimeDealProductSummary timeDealProductSummary = TimeDealProductSummary.builder()
+            DealProductSummary dealProductSummary = DealProductSummary.builder()
                 .dealProductUuid(timeDealProduct.getDealProductUuid())
                 .dealProductTile(timeDealProduct.getDealProductTile())
                 .productMainImgThumbnailUrl(timeDealProduct.getProductMainImgThumbnailUrl())
@@ -82,7 +82,7 @@ public class DealQueryRepository {
                 .dealProductStatus(timeDealProduct.getDealProductStatus())
                 .build();
 
-            timeDealProductSummaries.add(timeDealProductSummary);
+            timeDealProductSummaries.add(dealProductSummary);
         }
 
         return timeDealProductSummaries;

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealService.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealService.java
@@ -16,9 +16,9 @@ public class DealService {
         this.dealQueryRepository = dealQueryRepository;
     }
 
-    public List<TimeDealProductSummary> getDealProductsByDealType(DealType dealType, int pageNumber, ProductsSort sort) {
+    public List<DealProductSummary> getDealProductsByDealType(DealType dealType, int pageNumber, ProductsSort sort) {
 
-        List<TimeDealProductSummary> dealProducts = dealQueryRepository.getDealProductsByDealType(dealType, pageNumber, sort);
+        List<DealProductSummary> dealProducts = dealQueryRepository.getDealProductsByDealType(dealType, pageNumber, sort);
 
         return dealProducts;
     }

--- a/src/test/java/com/hcommerce/heecommerce/deal/DealControllerTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/deal/DealControllerTest.java
@@ -40,9 +40,9 @@ class DealControllerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private TimeDealProductSummary timeDealProductSummaryFixture;
+    private DealProductSummary dealProductSummaryFixture;
 
-    private List<TimeDealProductSummary> dealProductsFixture;
+    private List<DealProductSummary> dealProductsFixture;
 
     private PageDto pageDtoFixture;
 
@@ -61,7 +61,7 @@ class DealControllerTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        timeDealProductSummaryFixture = TimeDealProductSummary.builder()
+        dealProductSummaryFixture = DealProductSummary.builder()
                 .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342077"))
                 .dealProductTile("1000원 할인 상품 1")
                 .productMainImgThumbnailUrl("/test.png")
@@ -73,9 +73,9 @@ class DealControllerTest {
                 .build();
 
         dealProductsFixture = new ArrayList<>();
-        dealProductsFixture.add(timeDealProductSummaryFixture);
+        dealProductsFixture.add(dealProductSummaryFixture);
 
-        pageDtoFixture = PageDto.<TimeDealProductSummary>builder()
+        pageDtoFixture = PageDto.<DealProductSummary>builder()
                 .pageNumber(PAGE_NUMBER)
                 .pageSize(20)
                 .totalCount(dealProductsFixture.size())

--- a/src/test/java/com/hcommerce/heecommerce/deal/DealProductSummaryTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/deal/DealProductSummaryTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
 @DisplayName("TimeDealProductSummary")
-class TimeDealProductSummaryTest {
+class DealProductSummaryTest {
 
-    private List<TimeDealProductSummary> dealProductsFixture;
+    private List<DealProductSummary> dealProductsFixture;
 
     @BeforeEach
     void setUp() {
@@ -22,7 +22,7 @@ class TimeDealProductSummaryTest {
 
         dealProductsFixture = new ArrayList<>();
 
-        dealProductsFixture.add(TimeDealProductSummary.builder()
+        dealProductsFixture.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342077"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -33,7 +33,7 @@ class TimeDealProductSummaryTest {
             .dealProductStatus(DealProductStatus.BEFORE_OPEN)
             .build());
 
-        dealProductsFixture.add(TimeDealProductSummary.builder()
+        dealProductsFixture.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342075"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -44,7 +44,7 @@ class TimeDealProductSummaryTest {
             .dealProductStatus(DealProductStatus.BEFORE_OPEN)
             .build());
 
-        dealProductsFixture.add(TimeDealProductSummary.builder()
+        dealProductsFixture.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342073"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -65,9 +65,9 @@ class TimeDealProductSummaryTest {
     @DisplayName("sorted in ascending order of price")
     void It_Sorted_In_Ascending_Order_Of_Price() {
         // given
-        List<TimeDealProductSummary> expectedDealProducts = new ArrayList<>();
+        List<DealProductSummary> expectedDealProducts = new ArrayList<>();
 
-        expectedDealProducts.add(TimeDealProductSummary.builder()
+        expectedDealProducts.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342073"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -78,7 +78,7 @@ class TimeDealProductSummaryTest {
             .dealProductStatus(DealProductStatus.BEFORE_OPEN)
             .build());
 
-        expectedDealProducts.add(TimeDealProductSummary.builder()
+        expectedDealProducts.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342075"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -89,7 +89,7 @@ class TimeDealProductSummaryTest {
             .dealProductStatus(DealProductStatus.BEFORE_OPEN)
             .build());
 
-        expectedDealProducts.add(TimeDealProductSummary.builder()
+        expectedDealProducts.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342077"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -101,7 +101,7 @@ class TimeDealProductSummaryTest {
             .build());
 
         // when
-        List<TimeDealProductSummary> resultDealProducts = TimeDealProductSummary.sortDealProducts(dealProductsFixture, ProductsSort.PRICE_ASC);
+        List<DealProductSummary> resultDealProducts = DealProductSummary.sortDealProducts(dealProductsFixture, ProductsSort.PRICE_ASC);
 
         // given
         for (int i = 0; i < expectedDealProducts.size(); i++) {
@@ -113,9 +113,9 @@ class TimeDealProductSummaryTest {
     @Test
     void It_Sorted_In_Descending_Order_Of_Price() {
         // given
-        List<TimeDealProductSummary> expectedDealProducts = new ArrayList<>();
+        List<DealProductSummary> expectedDealProducts = new ArrayList<>();
 
-        expectedDealProducts.add(TimeDealProductSummary.builder()
+        expectedDealProducts.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342073"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -126,7 +126,7 @@ class TimeDealProductSummaryTest {
             .dealProductStatus(DealProductStatus.BEFORE_OPEN)
             .build());
 
-        expectedDealProducts.add(TimeDealProductSummary.builder()
+        expectedDealProducts.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342075"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -137,7 +137,7 @@ class TimeDealProductSummaryTest {
             .dealProductStatus(DealProductStatus.BEFORE_OPEN)
             .build());
 
-        expectedDealProducts.add(TimeDealProductSummary.builder()
+        expectedDealProducts.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342077"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -149,7 +149,7 @@ class TimeDealProductSummaryTest {
             .build());
 
         // when
-        List<TimeDealProductSummary> resultDealProducts = TimeDealProductSummary.sortDealProducts(dealProductsFixture, ProductsSort.PRICE_DESC);
+        List<DealProductSummary> resultDealProducts = DealProductSummary.sortDealProducts(dealProductsFixture, ProductsSort.PRICE_DESC);
 
         // given
         for (int i = 0; i < expectedDealProducts.size(); i++) {

--- a/src/test/java/com/hcommerce/heecommerce/deal/DealServiceTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/deal/DealServiceTest.java
@@ -32,11 +32,11 @@ class DealServiceTest {
 
     private static final ProductsSort SORT = ProductsSort.BASIC;
 
-    private List<TimeDealProductSummary> dealProductsFixture = new ArrayList<>();
+    private List<DealProductSummary> dealProductsFixture = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
-        dealProductsFixture.add(TimeDealProductSummary.builder()
+        dealProductsFixture.add(DealProductSummary.builder()
             .dealProductUuid(UUID.fromString("01b8851c-d046-4635-83c1-eb0ca4342077"))
             .dealProductTile("1000원 할인 상품 1")
             .productMainImgThumbnailUrl("/test.png")
@@ -59,7 +59,7 @@ class DealServiceTest {
             given(dealQueryRepository.getDealProductsByDealType(DEAL_TYPE_TIME_DEAL, PAGE_NUMBER, SORT)).willReturn(dealProductsFixture);
 
             // when
-            List<TimeDealProductSummary> dealProducts = dealService.getDealProductsByDealType(DEAL_TYPE_TIME_DEAL, PAGE_NUMBER, SORT);
+            List<DealProductSummary> dealProducts = dealService.getDealProductsByDealType(DEAL_TYPE_TIME_DEAL, PAGE_NUMBER, SORT);
 
             // then
             assertEquals(dealProducts.size(), dealProductsFixture.size());


### PR DESCRIPTION
# What
- [이 맥락](https://github.com/f-lab-edu/hee-commerce/pull/47#discussion_r1233357775)에서 나온 PR입니다.

# Why
- 다양항 딜 유형에 따라 다른 DealProductSummary을 가질 것 같다고 생각했으나, 티몬 등을 살펴보면서 딜 유형들(예 : 오늘의 딜, 100원 딜, 타임 딜) 목록 페이지에서 보여주는 `정보`와 `정렬 방식`도 동일했습니다. 그래서, 원래는 상속을 이용해서 딜 유형별 클래스를 만들려고 했으나, 동일한 정보가 필요하므로, 좀더 포괄적인 네이밍으로 수정하기로 결정했습니다.

# Comment
- 이거는 단순히 renaming한거라 일단 Merge 해서 진행하고 있을게요! 혹시 남겨주실 코멘트 있으시면 남겨주세요!