### PR TITLE
`DealProductStatus` 필드를 `DealProductSummaryResponse`에서만 관리하도록 수정

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/deal/DealController.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealController.java
@@ -31,14 +31,16 @@ public class DealController {
 
         List<DealProductSummary> dealProducts = dealService.getDealProductsByDealType(dealType, pageNumber, sort);
 
+        List<DealProductSummaryResponse> dealProductSummaryResponses = DealProductSummaryResponse.convertDealProductSummariesToDealProductSummaryResponses(dealProducts);
+
         return ResponseDto.builder()
                 .code(HttpStatus.OK.name())
                 .message("딜 상품 목록 조회 성공하였습니다.")
-                .data(PageDto.<DealProductSummary>builder()
+                .data(PageDto.<DealProductSummaryResponse>builder()
                         .pageNumber(0)
                         .pageSize(20)
                         .totalCount(dealProducts.size())
-                        .items(dealProducts)
+                        .items(dealProductSummaryResponses)
                         .build())
                 .build();
     }

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealProductSummary.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealProductSummary.java
@@ -20,7 +20,6 @@ public class DealProductSummary {
     private final DiscountType dealProductDiscountType;
     private final int dealProductDiscountValue;
     private final int dealProductDealQuantity;
-    private final DealProductStatus dealProductStatus;
     private final Instant startedAt;
     private final Instant finishedAt;
 
@@ -33,7 +32,6 @@ public class DealProductSummary {
         DiscountType dealProductDiscountType,
         int dealProductDiscountValue,
         int dealProductDealQuantity,
-        DealProductStatus dealProductStatus,
         Instant startedAt,
         Instant finishedAt
     ) {
@@ -44,7 +42,6 @@ public class DealProductSummary {
         this.dealProductDiscountType = dealProductDiscountType;
         this.dealProductDiscountValue = dealProductDiscountValue;
         this.dealProductDealQuantity = dealProductDealQuantity;
-        this.dealProductStatus = dealProductStatus;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
     }

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealProductSummaryResponse.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealProductSummaryResponse.java
@@ -1,0 +1,107 @@
+package com.hcommerce.heecommerce.deal;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DealProductSummaryResponse extends DealProductSummary {
+
+    private final DealProductStatus dealProductStatus;
+
+    @Builder
+    public DealProductSummaryResponse(
+        UUID dealProductUuid,
+        String dealProductTile,
+        String productMainImgThumbnailUrl,
+        int productOriginPrice,
+        DiscountType dealProductDiscountType,
+        int dealProductDiscountValue,
+        int dealProductDealQuantity,
+        DealProductStatus dealProductStatus,
+        Instant startedAt,
+        Instant finishedAt
+    ) {
+        super(
+            dealProductUuid,
+            dealProductTile,
+            productMainImgThumbnailUrl,
+            productOriginPrice,
+            dealProductDiscountType,
+            dealProductDiscountValue,
+            dealProductDealQuantity,
+            startedAt,
+            finishedAt
+        );
+        this.dealProductStatus = dealProductStatus;
+    }
+
+    public static List<DealProductSummaryResponse> convertDealProductSummariesToDealProductSummaryResponses(List<DealProductSummary> dealProductSummaies) {
+        List<DealProductSummaryResponse> dealProductSummaryResponseList = new ArrayList<>();
+
+        for (int i = 0; i < dealProductSummaies.size(); i++) {
+            DealProductSummary dealProductSummary = dealProductSummaies.get(i);
+
+            DealProductSummaryResponse dealProductSummaryResponse = DealProductSummaryResponse.builder()
+                .dealProductUuid(dealProductSummary.getDealProductUuid())
+                .dealProductTile(dealProductSummary.getDealProductTile())
+                .productMainImgThumbnailUrl(dealProductSummary.getProductMainImgThumbnailUrl())
+                .productOriginPrice(dealProductSummary.getProductOriginPrice())
+                .dealProductDiscountType(dealProductSummary.getDealProductDiscountType())
+                .dealProductDiscountValue(dealProductSummary.getDealProductDiscountValue())
+                .dealProductDealQuantity(dealProductSummary.getDealProductDealQuantity())
+                .dealProductStatus(determineDealProductStatus(dealProductSummary))
+                .startedAt(dealProductSummary.getStartedAt())
+                .finishedAt(dealProductSummary.getFinishedAt())
+                .build();
+
+            dealProductSummaryResponseList.add(dealProductSummaryResponse);
+        }
+
+        return dealProductSummaryResponseList;
+    }
+
+    private static DealProductStatus determineDealProductStatus(DealProductSummary dealProductSummary) {
+        ZoneId seoulZone = ZoneId.of("Asia/Seoul");
+
+        Instant currentInstant = ZonedDateTime.now(seoulZone).toInstant();
+
+        // 현재 시간이 오픈 이후면서 마감 이전인 경우
+        if(currentInstant.isAfter(dealProductSummary.getStartedAt()) && currentInstant.isBefore(dealProductSummary.getFinishedAt())) {
+            return DealProductStatus.OPEN;
+        }
+
+        // 현재 시간이 오픈 이후이면서 품절된 경우
+        if(currentInstant.isAfter(dealProductSummary.getStartedAt()) && dealProductSummary.getDealProductDealQuantity() <= 0) {
+            return DealProductStatus.SOLD_OUT;
+        }
+
+        // 현재시간이 마감 이후이면, 오후12시 이전인 경우
+        if(currentInstant.isAfter(dealProductSummary.getFinishedAt()) && currentInstant.isBefore(createPM12()) ) {
+            return DealProductStatus.CLOSE;
+        }
+
+        // 현재 시간이 오후 12시 이후 이면서 오픈 이전인 경우
+        return DealProductStatus.BEFORE_OPEN;
+    }
+
+    /**
+     * createPM12 는 서울 기준으로 오후 12시 인 Instant 타입을 return 해주는 함수이다.
+     */
+    private static Instant createPM12() {
+        LocalDate currentDate = LocalDate.now();
+
+        LocalTime noonTime = LocalTime.of(12, 0);
+
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(currentDate, noonTime, ZoneId.of("Asia/Seoul"));
+
+        return zonedDateTime.toInstant();
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/deal/DealQueryRepository.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/DealQueryRepository.java
@@ -81,7 +81,6 @@ public class DealQueryRepository {
                 .dealProductDiscountType(timeDealProductEntity.getDealProductDiscountType())
                 .dealProductDiscountValue(timeDealProductEntity.getDealProductDiscountValue())
                 .dealProductDealQuantity(timeDealProductEntity.getDealProductDealQuantity())
-                .dealProductStatus(timeDealProductEntity.getDealProductStatus())
                 .startedAt(timeDealProductEntity.getStartedAt())
                 .finishedAt(timeDealProductEntity.getFinishedAt())
                 .build();
@@ -161,7 +160,6 @@ public class DealQueryRepository {
                     .dealProductDealQuantity(3)
                     .productDetailImgUrls(new String[]{"/detail_test1.png", "/detail_test2.png", "/detail_test3.png", "/detail_test4.png", "/detail_test5.png"})
                     .productMainImgUrl("/main_test.png")
-                    .dealProductStatus(DealProductStatus.BEFORE_OPEN)
                     .maxOrderQuantityPerOrder(10)
                     .startedAt(startedAt)
                     .finishedAt(finishedAt)

--- a/src/main/java/com/hcommerce/heecommerce/deal/TimeDealProductEntity.java
+++ b/src/main/java/com/hcommerce/heecommerce/deal/TimeDealProductEntity.java
@@ -7,6 +7,15 @@ import lombok.Builder;
 import lombok.Getter;
 
 
+/**
+ * TimeDealProductEntity는 Redis에 저장되는 딜 상품 클래스이다.
+ *
+ * 딜 상품은 Redis에 다음과 같은 형태로 저장된다.
+ * RedisKey : timeDealProducts:{dealOpenDate(yyyyMMdd)}
+ * HashKey : {dealProductUuid}
+ * HashValue : {TimeDealProductEntity}
+ *
+ */
 @Getter
 public class TimeDealProductEntity {
 
@@ -19,7 +28,6 @@ public class TimeDealProductEntity {
     private final int dealProductDealQuantity;
     private final String[] productDetailImgUrls;
     private final String productMainImgThumbnailUrl;
-    private final DealProductStatus dealProductStatus;
     private final int maxOrderQuantityPerOrder;
     private final Instant startedAt;
     private final Instant finishedAt;
@@ -35,7 +43,6 @@ public class TimeDealProductEntity {
         "dealProductDealQuantity",
         "productDetailImgUrls",
         "productMainImgThumbnailUrl",
-        "dealProductStatus",
         "maxOrderQuantityPerOrder",
         "startedAt",
         "finishedAt"
@@ -50,7 +57,6 @@ public class TimeDealProductEntity {
         int dealProductDealQuantity,
         String[] productDetailImgUrls,
         String productMainImgThumbnailUrl,
-        DealProductStatus dealProductStatus,
         int maxOrderQuantityPerOrder,
         Instant startedAt,
         Instant finishedAt
@@ -64,7 +70,6 @@ public class TimeDealProductEntity {
         this.dealProductDealQuantity = dealProductDealQuantity;
         this.productDetailImgUrls = productDetailImgUrls;
         this.productMainImgThumbnailUrl = productMainImgThumbnailUrl;
-        this.dealProductStatus = dealProductStatus;
         this.maxOrderQuantityPerOrder = maxOrderQuantityPerOrder;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;


### PR DESCRIPTION
# What
- DealProductStatus 필드를 DealProductSummaryResponse에서만 관리하도록 수정하기 위해 다음 작업을 했습니다.
1. `TimeDealProductEntity`와 `DealProductSummary`의 `DealProductStatus` 필드 삭제
2. `DealProductStatus` 가진 `DealProductSummaryResponse` 추가 

# Comment
- 위와 같이 한 이유는 다음과 같습니다.
1. 프론트에서 UI에서 필ㅇ
