### PR TITLE
`TimeDealProductEntity`에서 `dealProductDealQuantity`삭제에 따른 딜 상품 목록/상세 조회 로직 수정

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/common/dao/RedisStringsRepository.java
+++ b/src/main/java/com/hcommerce/heecommerce/common/dao/RedisStringsRepository.java
@@ -1,5 +1,7 @@
 package com.hcommerce.heecommerce.common.dao;
 
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -34,6 +36,26 @@ public class RedisStringsRepository {
 
     public String get(String key) {
         return redisTemplate.opsForValue().get(key);
+    }
+
+    /**
+     * getMany 는 요청된 key의 순서대로 Redis에 Strings 데이터 타입으로 저장된 여러 데이터들을 얻는 함수이다.
+     * 만약, 존재하지 않는 key 가 있으면, 그 key 순서의 결과값은 null 이다.
+     * <예시1>
+     * redis> MGET key1 key2 nonExistingKey
+     * 1) "Hello"
+     * 2) "World"
+     * 3) (nil)
+     * <예시2>
+     * redis> MGET key1 nonExistingKey key2
+     * 1) "Hello"
+     * 2) (nil)
+     * 3) "World"
+     *
+     * Set 으로 한 이유는 중복된 key 검색을 방지를 하기 위해서이다.
+     */
+    public List<String> getMany(Set<String> keys) {
+        return redisTemplate.opsForValue().multiGet(keys);
     }
 
     public long decreaseByAmount(String key, long amount) {

--- a/src/main/java/com/hcommerce/heecommerce/common/utils/TypeConversionUtils.java
+++ b/src/main/java/com/hcommerce/heecommerce/common/utils/TypeConversionUtils.java
@@ -1,9 +1,41 @@
 package com.hcommerce.heecommerce.common.utils;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class TypeConversionUtils {
+
+    // TODO : 현재 String 리스트 -> Integer 리스트 변환하는데, 추후에 제네릭을 이용해서 다양한 타입을 다양한 타입으로 변환할 수 있게 만들기
+    public static List<Integer> convertStringsToIntegers(List<String> strings) {
+        List<Integer> integers = new ArrayList<>();
+
+        for (int i = 0; i < strings.size(); i++) {
+            integers.add(Integer.valueOf(strings.get(i)));
+        }
+
+        return integers;
+    }
+
+    /**
+     * createMapByTwoList 는 2개의 리스트를 이용해서 Map을 만드는 함수 이다.
+     */
+    public static <K, V> Map<K, V> convertTwoListToMap(List<K> keys, List<V> values) {
+        Map<K, V> map = new ConcurrentHashMap<>();
+
+        for (int i = 0; i < keys.size(); i++) {
+            K key = keys.get(i);
+
+            V value = values.get(i);
+
+            map.put(key, value);
+        }
+
+        return map;
+    }
 
     public static UUID convertBinaryToUuid(byte[] bytes) {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);

--- a/src/main/java/com/hcommerce/heecommerce/inventory/InventoryQueryRepository.java
+++ b/src/main/java/com/hcommerce/heecommerce/inventory/InventoryQueryRepository.java
@@ -1,6 +1,9 @@
 package com.hcommerce.heecommerce.inventory;
 
 import com.hcommerce.heecommerce.common.dao.RedisStringsRepository;
+import com.hcommerce.heecommerce.common.utils.TypeConversionUtils;
+import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +19,11 @@ public class InventoryQueryRepository {
 
     public int get(String key) {
         return Integer.valueOf(redisStringsRepository.get(key));
+    }
+
+    public List<Integer> getMany(Set<String> keys) {
+        List<String> inventories = redisStringsRepository.getMany(keys);
+
+        return TypeConversionUtils.convertStringsToIntegers(inventories);
     }
 }

--- a/src/test/java/com/hcommerce/heecommerce/common/utils/TypeConversionUtilsTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/common/utils/TypeConversionUtilsTest.java
@@ -3,13 +3,78 @@ package com.hcommerce.heecommerce.common.utils;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("TypeConversionUtils")
 class TypeConversionUtilsTest {
+
+    // TODO : 예외 케이스 테스트 추가 필요함(예 : strings의 길이가 0일 때, 숫자인 문자가 아닌 경우 등)
+    @Nested
+    @DisplayName("convertStringsToIntegers")
+    class Describe_ConvertStringsToIntegers {
+        @Test
+        @DisplayName("returns integerArrayList")
+        void It_returns_IntegerArrayList() {
+            // Given
+            List<String> strings = new ArrayList<>();
+            strings.add("1");
+            strings.add("2");
+            strings.add("3");
+
+            // When
+            List<Integer> integers = TypeConversionUtils.convertStringsToIntegers(strings);
+
+            // Then
+            List<Integer> expectedIntegers = new ArrayList<>();
+            expectedIntegers.add(1);
+            expectedIntegers.add(2);
+            expectedIntegers.add(3);
+
+            for (int i = 0; i < expectedIntegers.size(); i++) {
+                assertEquals(expectedIntegers.get(i), integers.get(i));
+            }
+        }
+    }
+
+    // TODO : 예외 케이스 테스트 추가 필요함(예 : 2개의 배열 중 한개라도 길이가 0일 때, 또는 갯수가 안 맞을 때)
+    @Nested
+    @DisplayName("convertTwoListToMap")
+    class Describe_ConvertTwoListToMap {
+        @Test
+        @DisplayName("returns map")
+        void It_returns_Map() {
+            // Given
+            List<String> strings = new ArrayList<>();
+            strings.add("1");
+            strings.add("2");
+            strings.add("3");
+
+            List<Integer> integers = new ArrayList<>();
+            integers.add(10);
+            integers.add(20);
+            integers.add(30);
+
+            // When
+            Map<String, Integer> map = TypeConversionUtils.convertTwoListToMap(strings, integers);
+
+            // Then
+            Map<String, Integer> expectedMap = new ConcurrentHashMap<>();
+            expectedMap.put("1", 10);
+            expectedMap.put("2", 20);
+            expectedMap.put("3", 30);
+
+            for (int i = 0; i < strings.size(); i++) {
+                assertEquals(expectedMap.get(strings.get(i)), map.get(strings.get(i)));
+            }
+        }
+    }
 
     @Nested
     @DisplayName("convertBinaryToUuid")


### PR DESCRIPTION
# What
- TimeDealProductEntity에서 dealProductDealQuantity 삭제에 따른 딜 상품 목록/상세 조회 로직 수정

# Comment
- 이렇게 직접 구현해보니, 딜상품과 재고를 분리하는 구조가 애플리케이션 코드를 많이 복잡하게 만든다는 걸 깨달았네요.
- 재고를 딜상품에 합치는게 나을 수도 있다고 생각하는데, 일단 구현부터 하고 수정이 필요하면 그때 수정하도록 하겠습니다.
- 주문 API에 집중하기로 해서, 가볍게 봐주셔도 괜찮을 것 같아요!
- 일단은 해당 로직이 테스트 할 때 필요할 것 같아서 작업했어요. 
