### PR TITLE
`OrderCommanRepository`에서 `saveOrderInAdvance`추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	// devtools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+	// mybatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.1'
+
 	// mysql
 	implementation 'mysql:mysql-connector-java:8.0.22'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/hcommerce/heecommerce/common/utils/TypeConversionUtils.java
+++ b/src/main/java/com/hcommerce/heecommerce/common/utils/TypeConversionUtils.java
@@ -1,0 +1,21 @@
+package com.hcommerce.heecommerce.common.utils;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class TypeConversionUtils {
+
+    public static UUID convertBinaryToUuid(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        long mostSignificantBits = buffer.getLong();
+        long leastSignificantBits = buffer.getLong();
+        return new UUID(mostSignificantBits, leastSignificantBits);
+    }
+
+    public static byte[] convertUuidToBinary(UUID uuid) {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
+        byteBuffer.putLong(uuid.getMostSignificantBits());
+        byteBuffer.putLong(uuid.getLeastSignificantBits());
+        return byteBuffer.array();
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderCommandMapper.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderCommandMapper.java
@@ -1,0 +1,9 @@
+package com.hcommerce.heecommerce.order;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OrderCommandMapper {
+
+    void saveOrderInAdvance(OrderFormSavedInAdvanceEntity orderFormSavedInAdvanceEntity);
+}

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderCommandRepository.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderCommandRepository.java
@@ -1,11 +1,19 @@
 package com.hcommerce.heecommerce.order;
 
-import org.springframework.stereotype.Repository;
-
+import com.hcommerce.heecommerce.common.utils.TypeConversionUtils;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public class OrderCommandRepository {
+
+    private final OrderCommandMapper orderCommandMapper;
+
+    @Autowired
+    public OrderCommandRepository(OrderCommandMapper orderCommandMapper) {
+        this.orderCommandMapper = orderCommandMapper;
+    }
 
     public UUID updateToCompleteOrderReceipt(UUID orderUuid) {
         String newOrderStatus = OrderStatus.ORDER_RECEIPT_COMPLETE.name();
@@ -42,6 +50,13 @@ public class OrderCommandRepository {
          */
 
         return orderUuid;
+    }
+
+    public UUID saveOrderInAdvance(OrderFormSavedInAdvanceEntity orderFormSavedInAdvanceEntity) {
+
+        orderCommandMapper.saveOrderInAdvance(orderFormSavedInAdvanceEntity);
+
+        return TypeConversionUtils.convertBinaryToUuid(orderFormSavedInAdvanceEntity.getUuid());
     }
 }
 

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderFormSavedInAdvanceEntity.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderFormSavedInAdvanceEntity.java
@@ -1,0 +1,38 @@
+package com.hcommerce.heecommerce.order;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrderFormSavedInAdvanceEntity {
+
+    private final byte[] uuid;
+    private final OrderStatus orderStatus;
+    private final int userId;
+    private final OutOfStockHandlingOption outOfStockHandlingOption;
+    private final byte[] dealProductUuid;
+    private final int orderQuantity;
+    private final PaymentMethod paymentMethod;
+    private final RecipientInfoForm recipientInfoForm;
+
+    @Builder
+    public OrderFormSavedInAdvanceEntity(
+        byte[] uuid,
+        OrderStatus orderStatus,
+        int userId,
+        OutOfStockHandlingOption outOfStockHandlingOption,
+        byte[] dealProductUuid,
+        int orderQuantity,
+        RecipientInfoForm recipientInfoForm,
+        PaymentMethod paymentMethod
+    ) {
+        this.uuid = uuid;
+        this.orderStatus = orderStatus;
+        this.userId = userId;
+        this.outOfStockHandlingOption = outOfStockHandlingOption;
+        this.dealProductUuid = dealProductUuid;
+        this.orderQuantity = orderQuantity;
+        this.recipientInfoForm = recipientInfoForm;
+        this.paymentMethod = paymentMethod;
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderStatus.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderStatus.java
@@ -1,7 +1,15 @@
 package com.hcommerce.heecommerce.order;
 
+/**
+ * OrderStatus 는 주문 상태를 관리하는 Enum 클래스이다.
+ * TODO : 일단 생각나는 상태들만 추가하였고, 추후에 확장성을 고려해서 더 다양한 상태를 담을 수 있고, 상태 간의 전환에 대한 예외처리도 생각해볼 예정
+ */
 public enum OrderStatus {
-    ORDER_RECEIPT_COMPLETE,
+    ORDER_RECEIPT_COMPLETE, // TODO : 삭제 예정
+    PAYMENT_PENDING,
+    PAYMENT_COMPLETED,
+    PAYMENT_CANCELLED,
+    DELIVERY_PENDING,
     IN_DELIVERY,
-    DELIVERY_COMPLETE,
+    DELIVERY_COMPLETED
 }

--- a/src/main/resources/db/migration/V1.1__update_order.sql
+++ b/src/main/resources/db/migration/V1.1__update_order.sql
@@ -1,0 +1,36 @@
+drop table if exists `order`;
+drop table if exists `partial_order`;
+
+CREATE TABLE `order` (
+  # 주문
+  `uuid` binary(16) PRIMARY KEY NOT NULL COMMENT '주문 식별자',
+  `order_status` varchar(255) NOT NULL COMMENT '주문 상태',
+  `user_id` bigint NOT NULL COMMENT '주문자 식별자',
+  `out_of_stock_handling_option` varchar(255) NOT NULL COMMENT '수량 부족 처리 옵션',
+  `deal_product_uuid` binary(16) NOT NULL COMMENT '딜 상품 식별자',
+  `ordered_at` timestamp COMMENT '주문 완료 일시',
+  `order_quantity` int NOT NULL COMMENT '주문 수량',
+  # 배송
+  `recipient_name` varchar(255) NOT NULL COMMENT '수령자 이름',
+  `recipient_phone_number` varchar(255) NOT NULL COMMENT '연락처',
+  `recipient_address` varchar(255) NOT NULL COMMENT '수령자 주소',
+  `recipient_detail_address` varchar(255) COMMENT '수령자 상세 주소',
+  `shipping_request` varchar(255) COMMENT '배송 요청 사항',
+  # 결제
+  `total_payment_amount` int COMMENT '총 결제 금액',
+  `payment_method` varchar(255) COMMENT '결제 수단',
+  `paid_at` timestamp COMMENT '결제 일시',
+  `previous_deal_quantity` int COMMENT '결제 전 딜상품 재고 수량',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_at` timestamp,
+  `deleted_at` timestamp
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `partial_order` (
+  `uuid` binary(16) PRIMARY KEY NOT NULL COMMENT '부분 주문 식별자',
+  `order_uuid` binary(16) NOT NULL COMMENT '주문 식별자',
+  `real_order_quantity` int NOT NULL COMMENT '실제 주문 처리된 수량',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_at` timestamp,
+  `deleted_at` timestamp
+)

--- a/src/main/resources/mappers/OrderCommandMapper.xml
+++ b/src/main/resources/mappers/OrderCommandMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hcommerce.heecommerce.order.OrderCommandMapper">
+
+  <!-- 검증을 위해 주문 내역 사전 저장  -->
+  <insert id="saveOrderInAdvance">
+    INSERT INTO `order` (
+      uuid, order_status, user_id, out_of_stock_handling_option, deal_product_uuid, order_quantity, payment_method,
+      recipient_name, recipient_phone_number, recipient_address, recipient_detail_address, shipping_request
+    ) values (
+      #{uuid}, #{orderStatus}, #{userId}, #{outOfStockHandlingOption}, #{dealProductUuid}, #{orderQuantity}, #{paymentMethod},
+      #{recipientInfoForm.recipientName}, #{recipientInfoForm.recipientPhoneNumber}, #{recipientInfoForm.recipientAddress}, #{recipientInfoForm.recipientDetailAddress}, #{recipientInfoForm.shippingRequest}
+    )
+  </insert>
+</mapper>


### PR DESCRIPTION
# What
- #32 
- 주문 데이터 사전 저장 기능([주문 API Flow Chart](https://app.diagrams.net/#G12p5UVtXs0pfISlmnFDNGlt4g1ignoKgO#%7B%22pageId%22%3A%22y5c_3sEjpOXRIoWMQFBl%22%7D))을 위한 `OrderCommanRepository`의 `saveOrderInAdvance` 추가
<img width="1026" alt="스크린샷 2023-07-04 오전 1 21 41" src="https://github.com/f-lab-edu/hee-commerce/assets/60481383/3c919d4b-da55-46b2-926f-902feafe11d8">

# Comment
- mybatis 코드 때문에 코드양이 좀 되네요😅
