### PR TITLE
타임 딜 상품 재고만을 관리하는 의도를 드러내기 위해 `inventory_event_histoy` ->  `time_deal_product_inventory_event_history` 수정

### DIFF
--- a/src/main/resources/db/migration/V1.3__drop_inventory_event_history.sql
+++ b/src/main/resources/db/migration/V1.3__drop_inventory_event_history.sql
@@ -1,0 +1,1 @@
+drop table if exists `inventory_event_history`;

--- a/src/main/resources/db/migration/V1.4__add_deal_product_inventory_event_history.sql
+++ b/src/main/resources/db/migration/V1.4__add_deal_product_inventory_event_history.sql
@@ -1,0 +1,13 @@
+drop table if exists `deal_product_inventory_event_history`;
+
+-- time_deal_product_inventory_event_history 는 딜 상품 재고 이벤트 히스토리를 저장하는 테이블로, 데이터 업데이트 없이 데이터를 추가만 하는 테이블이다.
+-- time_deal_product 테이블에 inventory 필드가 있는데, 이 테이플이 필요한 이유는 https://docs.google.com/document/d/1JlKVZVZQwWjxF3bbVW5a4K3YmnfC6gYYoMHhAn5JKLs/edit 참고
+CREATE TABLE `time_deal_product_inventory_event_history` (
+  `inventory_event_history_id` bigint PRIMARY KEY NOT NULL AUTO_INCREMENT, # 재고 이벤트 히스토리 식별자
+  `deal_product_uuid` binary(16) NOT NULL, # 딜 상품 식별자
+  `order_uuid` binary(16) NOT NULL, # 딜 상품 식별자
+  `inventory` int NOT NULL, # 이벤트로 처리된 재고 수량
+  `previous_deal_quantity` int NOT NULL, # 이벤트 전 재고 수량
+  `inventory_event_type` varchar(255) NOT NULL, # 이벤트 유형(예 : 주문 접수, 주문 취소)
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
# Why
- 타임딜 상품만 해당하는 재고 히스토리를 관리하는 테이블이라는 의도를 드러내고 싶었기 때문입니다.
- 일반적인 딜 상품의 경우에는 타임딜 처럼 주문이 몰리지 않아, MySQL에 바로 재고를 반영해도 되어, 이런 집계용 테이블이 필요하지 않습니다.
- 따라서, 타임딜 상품만을 위한 테이블이라는 의도를 드러내고 싶었습니다.

# Comment
- 추가로, 이렇게 재고 히스토리를 관리하는 테이블이 필요한 이유는 [구글 Dodcs](https://docs.google.com/document/d/1JlKVZVZQwWjxF3bbVW5a4K3YmnfC6gYYoMHhAn5JKLs/edit?disco=AAAA04Q2Pwg)에 정리해 두었습니다. 

