### PR TITLE
`calculateRealOrderQuantity`에서 `inventoryAfterDecrease`이 0일 경우 추가

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -119,7 +119,7 @@ public class OrderService {
             realOrderQuantity = inventoryBeforeDecrease; // 기존 재고량 만큼만 주문
         }
 
-        if(inventoryAfterDecrease > 0) { // case 3
+        if(inventoryAfterDecrease >= 0) { // case 3
             realOrderQuantity = orderQuantity;
         }
 


### PR DESCRIPTION
# Why
- 이전 코드에서 `inventoryAfterDecrease`이 0일 때에 주문 수량이 0이 아님에도 불구하고 realOrderQuantity 는 0을 반환하였습니다.
- `inventoryAfterDecrease`이 0일 때에도 `orderQuantity`  수량으로 주문이 가능하므로, 추가해주었습니다. 