### PR TITLE
`int` 대신 `Optional<Integer>`를 사용하여 동적 쿼리 -> 정적 쿼리로 수정

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/order/OrderFormSavedInAdvanceEntity.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderFormSavedInAdvanceEntity.java
@@ -3,6 +3,14 @@ package com.hcommerce.heecommerce.order;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * OrderFormSavedInAdvanceEntity 는 주문 내역 사전 저장에 필요한 클래스이다.
+ *
+ * 특히, originalOrderQuantityForPartialOrder 에 Integer 를 사용한 이유는 쿼리를 단순화 하고 싶었기 떄문이다.
+ * order 테이블에서 originalOrderQuantityForPartialOrder 는 부분 주문이 아닌 전체 주문인 경우에 Null 값을 갖는다.
+ * 그런데, int 의 경우, null 값을 허용하지 않아, 동적 쿼리를 필요로 하는데, 쿼리 작성이 복잡해지는 경향이 있다.
+ * 이에 null 값을 허용하는 Integer 로 데이터 타입을 바꿔 동적 쿼리를 제거할 수 있었다.
+ */
 @Getter
 public class OrderFormSavedInAdvanceEntity {
 
@@ -11,7 +19,7 @@ public class OrderFormSavedInAdvanceEntity {
     private final int userId;
     private final OutOfStockHandlingOption outOfStockHandlingOption;
     private final byte[] dealProductUuid;
-    private final int originalOrderQuantityForPartialOrder;
+    private final Integer originalOrderQuantityForPartialOrder;
     private final int realOrderQuantity;
     private final int totalPaymentAmount;
     private final PaymentMethod paymentMethod;
@@ -23,7 +31,7 @@ public class OrderFormSavedInAdvanceEntity {
         int userId,
         OutOfStockHandlingOption outOfStockHandlingOption,
         byte[] dealProductUuid,
-        int originalOrderQuantityForPartialOrder,
+        Integer originalOrderQuantityForPartialOrder,
         int realOrderQuantity,
         int totalPaymentAmount,
         PaymentMethod paymentMethod,

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderFormSavedInAdvanceEntity.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderFormSavedInAdvanceEntity.java
@@ -1,5 +1,6 @@
 package com.hcommerce.heecommerce.order;
 
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,7 +20,7 @@ public class OrderFormSavedInAdvanceEntity {
     private final int userId;
     private final OutOfStockHandlingOption outOfStockHandlingOption;
     private final byte[] dealProductUuid;
-    private final Integer originalOrderQuantityForPartialOrder;
+    private final Optional<Integer> originalOrderQuantityForPartialOrder;
     private final int realOrderQuantity;
     private final int totalPaymentAmount;
     private final PaymentMethod paymentMethod;
@@ -31,7 +32,7 @@ public class OrderFormSavedInAdvanceEntity {
         int userId,
         OutOfStockHandlingOption outOfStockHandlingOption,
         byte[] dealProductUuid,
-        Integer originalOrderQuantityForPartialOrder,
+        Optional<Integer> originalOrderQuantityForPartialOrder,
         int realOrderQuantity,
         int totalPaymentAmount,
         PaymentMethod paymentMethod,

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -224,7 +224,7 @@ public class OrderService {
 
         int totalPaymentAmount = calculateTotalPaymentAmount(timeDealProductDetail.getProductOriginPrice(), realOrderQuantity, timeDealProductDetail.getDealProductDiscountType(), timeDealProductDetail.getDealProductDiscountValue());
 
-        int originalOrderQuantityForPartialOrder = -1; // 부분 주문이 아닌 경우 값으로, Null 을 넣어주고 싶었으나, int 는 Null 을 헝용하지 않기 때문에, 임의의 값 넣어줌
+        Integer originalOrderQuantityForPartialOrder = null; // 부분 주문이 아닌 경우 값으로, Null 값을 가지므로,
 
         if(orderForm.getOutOfStockHandlingOption() == OutOfStockHandlingOption.PARTIAL_ORDER) {
             originalOrderQuantityForPartialOrder = orderForm.getOrderQuantity();

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -8,6 +8,7 @@ import com.hcommerce.heecommerce.deal.TimeDealProductDetail;
 import com.hcommerce.heecommerce.inventory.InventoryCommandRepository;
 import com.hcommerce.heecommerce.inventory.InventoryQueryRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
@@ -224,10 +225,10 @@ public class OrderService {
 
         int totalPaymentAmount = calculateTotalPaymentAmount(timeDealProductDetail.getProductOriginPrice(), realOrderQuantity, timeDealProductDetail.getDealProductDiscountType(), timeDealProductDetail.getDealProductDiscountValue());
 
-        Integer originalOrderQuantityForPartialOrder = null; // 부분 주문이 아닌 경우 값으로, Null 값을 가지므로,
+        Optional<Integer> originalOrderQuantityForPartialOrder = null; // 부분 주문이 아닌 경우 값으로, Null 값을 가지므로,
 
         if(orderForm.getOutOfStockHandlingOption() == OutOfStockHandlingOption.PARTIAL_ORDER) {
-            originalOrderQuantityForPartialOrder = orderForm.getOrderQuantity();
+            originalOrderQuantityForPartialOrder = Optional.of(orderForm.getOrderQuantity());
         }
 
         return OrderFormSavedInAdvanceEntity.builder()

--- a/src/main/resources/mappers/OrderCommandMapper.xml
+++ b/src/main/resources/mappers/OrderCommandMapper.xml
@@ -12,14 +12,7 @@
     recipient_name, recipient_phone_number, recipient_address, recipient_detail_address, shipping_request
     ) values (
     #{uuid}, #{orderStatus}, #{userId}, #{outOfStockHandlingOption}, #{dealProductUuid},
-    <choose>
-      <when test="originalOrderQuantityForPartialOrder == -1">
-        NULL
-      </when>
-      <otherwise>
-        #{originalOrderQuantityForPartialOrder}
-      </otherwise>
-    </choose>,
+    #{originalOrderQuantityForPartialOrder},
     #{realOrderQuantity}, #{paymentMethod}, #{totalPaymentAmount},
     #{recipientInfoForm.recipientName}, #{recipientInfoForm.recipientPhoneNumber}, #{recipientInfoForm.recipientAddress}, #{recipientInfoForm.recipientDetailAddress}, #{recipientInfoForm.shippingRequest}
     )


### PR DESCRIPTION
# Why
- 쿼리를 단순화 하고 싶었기 떄문이다.
 - order 테이블에서 originalOrderQuantityForPartialOrder 는 부분 주문이 아닌 전체 주문인 경우에 Null 값을 가집니다.
 - 그런데, int 의 경우, null 값을 허용하지 않아, 동적 쿼리를 필요로 하는데, 쿼리 가독성이 떨어진다고 생각했고, 
 - 이에 null 값을 허용하는 Integer 로 데이터 타입을 바꿔 동적 쿼리를 정적 쿼리로 바꿔보았습니다.
 - 추가로 [코멘트](https://github.com/f-lab-edu/hee-commerce/pull/120/files#r1258347086) 남겨주신 대로, Integer 보다 Optional<Integer>을 사용하는게 `Null 값을 가질 수 있는 값`이란 의도가 잘 드러나는 것 같아서,  Optional<Integer>을 사용했습니다.
