### PR TITLE
`InventoryCommandRepository`에 amount 양수 검증 추가

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/inventory/AmountIsNotPositiveException.java
+++ b/src/main/java/com/hcommerce/heecommerce/inventory/AmountIsNotPositiveException.java
@@ -1,0 +1,7 @@
+package com.hcommerce.heecommerce.inventory;
+
+public class AmountIsNotPositiveException extends RuntimeException {
+    public AmountIsNotPositiveException() {
+        super("수량이 양수인지 확인해주세요");
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/inventory/InventoryCommandRepository.java
+++ b/src/main/java/com/hcommerce/heecommerce/inventory/InventoryCommandRepository.java
@@ -31,14 +31,24 @@ public class InventoryCommandRepository extends InventoryRepository {
     }
 
     public int decreaseByAmount(UUID dealProductUuid, int amount) {
+        validationAmountIsPositive(amount);
+
         String key = super.getRedisKey(dealProductUuid);
 
         return (int) redisStringsRepository.decreaseByAmount(key, Long.valueOf(amount));
     }
 
     public void increaseByAmount(UUID dealProductUuid, int amount) {
+        validationAmountIsPositive(amount);
+
         String key = super.getRedisKey(dealProductUuid);
 
         redisStringsRepository.increaseByAmount(key, Long.valueOf(amount));
+    }
+
+    private void validationAmountIsPositive(int amount) {
+        if(amount <= 0) {
+            throw new AmountIsNotPositiveException();
+        }
     }
 }


### PR DESCRIPTION
# What
- 아래 맥락들에서 서 나온 PR
1.  https://github.com/f-lab-edu/hee-commerce/pull/135#discussion_r1262718272
2.  https://github.com/f-lab-edu/hee-commerce/pull/56#discussion_r1239620817
# Comment
1.  작업 우선순위에서는 후순위이지만, 다른 repositroy에도 특정 코너케이스들 처리해주는게 좋을까요? 아래의 경우를 예를 들면, `getMany`에서 `Set<String> uuidStrings`의 사이즈가 0일 때예요!
<img width="588" alt="스크린샷 2023-07-14 오후 9 53 40" src="https://github.com/f-lab-edu/hee-commerce/assets/60481383/be9f7c6c-6f57-439f-963d-b0f012c93ebf">

2. 이렇게 코너 케이스가 있는 경우에는 단위테스트를 작성해두는게 좋겠죠? 