### PR TITLE
`OrderService`의 `주문 사전 저장`의 일부 로직에 대한 책임을 `OrderService` -> `orderForm` 도메인 모델로 책임 변경 리팩토링

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
@@ -2,7 +2,7 @@ package com.hcommerce.heecommerce.order;
 
 import com.hcommerce.heecommerce.common.dto.ResponseDto;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
-import com.hcommerce.heecommerce.order.dto.OrderForm;
+import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.dto.OrderUuid;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -25,14 +25,14 @@ public class OrderController {
 
     /**
      * 검증을 위한 주문 데이터 사전 저장
-     * @param orderForm
+     * @param orderFormDto
      * @return
      */
     @PostMapping("/orders/place-in-advance")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseDto placeOrderInAdvance(@Valid @RequestBody OrderForm orderForm) {
+    public ResponseDto placeOrderInAdvance(@Valid @RequestBody OrderFormDto orderFormDto) {
 
-        UUID orderUuid = orderService.placeOrderInAdvance(orderForm);
+        UUID orderUuid = orderService.placeOrderInAdvance(orderFormDto);
 
         return ResponseDto.builder()
             .code(HttpStatus.CREATED.name())

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -5,8 +5,8 @@ import com.hcommerce.heecommerce.common.utils.DateTimeConversionUtils;
 import com.hcommerce.heecommerce.common.utils.TosspaymentsUtils;
 import com.hcommerce.heecommerce.common.utils.TypeConversionUtils;
 import com.hcommerce.heecommerce.deal.DealProductQueryRepository;
-import com.hcommerce.heecommerce.deal.enums.DiscountType;
 import com.hcommerce.heecommerce.deal.dto.TimeDealProductDetail;
+import com.hcommerce.heecommerce.deal.enums.DiscountType;
 import com.hcommerce.heecommerce.inventory.InventoryCommandRepository;
 import com.hcommerce.heecommerce.inventory.InventoryQueryRepository;
 import com.hcommerce.heecommerce.inventory.dto.InventoryIncreaseDecreaseDto;
@@ -21,7 +21,6 @@ import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.InvalidPaymentAmountException;
 import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
 import com.hcommerce.heecommerce.order.exception.OrderOverStockException;
-import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
 import com.hcommerce.heecommerce.order.model.TossPaymentsApproveResultForStorage;
 import com.hcommerce.heecommerce.payment.TosspaymentsException;
 import java.util.UUID;
@@ -94,7 +93,9 @@ public class OrderService {
         int orderQuantity = orderForm.getOrderQuantity();
 
         // 1. DB에 존재하는 dealProductUuid 인지
-        validateHasDealProductUuid(dealProductUuid);
+        boolean hasDealProductUuid = dealProductQueryRepository.hasDealProductUuid(dealProductUuid);
+
+        orderForm.validateHasDealProductUuid(hasDealProductUuid);
 
         // 2. DB에 존재하는 userId 인지
         // TODO : 회원 기능 추가 후 구현
@@ -169,17 +170,6 @@ public class OrderService {
         }
 
         return realOrderQuantity;
-    }
-
-    /**
-     * validateHasDealProductUuid 는 DB에 존재하는 dealProductUuid 인지 검사하는 함수이다.
-     */
-    private void validateHasDealProductUuid(UUID dealProductUuid) {
-        boolean hasDealProductUuid = dealProductQueryRepository.hasDealProductUuid(dealProductUuid);
-
-        if(!hasDealProductUuid) {
-            throw new TimeDealProductNotFoundException(dealProductUuid);
-        }
     }
 
     /**

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -19,7 +19,6 @@ import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.entity.OrderFormSavedInAdvanceEntity;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.InvalidPaymentAmountException;
-import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
 import com.hcommerce.heecommerce.order.exception.OrderOverStockException;
 import com.hcommerce.heecommerce.order.model.TossPaymentsApproveResultForStorage;
 import com.hcommerce.heecommerce.payment.TosspaymentsException;
@@ -101,7 +100,9 @@ public class OrderService {
         // TODO : 회원 기능 추가 후 구현
 
         // 3. 최대 주문 수량에 맞는 orderQuantity 인지
-        validateOrderQuantityInMaxOrderQuantityPerOrder(dealProductUuid, orderQuantity);
+        int maxOrderQuantityPerOrder = dealProductQueryRepository.getMaxOrderQuantityPerOrderByDealProductUuid(dealProductUuid);
+
+        orderForm.validateOrderQuantityInMaxOrderQuantityPerOrder(maxOrderQuantityPerOrder);
 
         // 4. 실제 주문 수량 계산
         OutOfStockHandlingOption outOfStockHandlingOption = orderForm.getOutOfStockHandlingOption();
@@ -170,17 +171,6 @@ public class OrderService {
         }
 
         return realOrderQuantity;
-    }
-
-    /**
-     * validateOrderQuantityInMaxOrderQuantityPerOrder 는 최대 주문 수량에 맞는지에 대해 검증하는 함수이다.
-     */
-    private void validateOrderQuantityInMaxOrderQuantityPerOrder(UUID dealProductUuid, int orderQuantity) {
-        int maxOrderQuantityPerOrder = dealProductQueryRepository.getMaxOrderQuantityPerOrderByDealProductUuid(dealProductUuid);
-
-        if(orderQuantity > maxOrderQuantityPerOrder) {
-            throw new MaxOrderQuantityExceededException(maxOrderQuantityPerOrder);
-        }
     }
 
     /**

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -65,23 +65,6 @@ public class OrderService {
     }
 
     /**
-     * rollbackReducedInventory 는 임의로 감소시킨 재고량을 다시 원상복귀하기 위한 함수이다.
-     * 함수로 만든 이유는 다양한 원인으로 재고량을 rollback 시켜줘야 하므로, 함수로 만들어 재활용하고 싶었기 때문이다.
-     * @param dealProductUuid : 원상복귀해야 하는 딜 상품 key
-     * @param amount : 원상복귀해야 하는 재고량
-     */
-    private void rollbackReducedInventory(InventoryEventType inventoryEventType, UUID dealProductUuid, UUID orderUuid, int amount) {
-        log.error("[rollback] inventoryEventType = {}, dealProductUuid = {}, orderUuid = {}, amount = {} ", inventoryEventType, dealProductUuid, orderUuid, amount);
-
-        inventoryCommandRepository.increase(InventoryIncreaseDecreaseDto.builder()
-            .dealProductUuid(dealProductUuid)
-            .orderUuid(orderUuid)
-            .inventory(amount)
-            .inventoryEventType(inventoryEventType)
-            .build());
-    }
-
-    /**
      * placeOrderInAdvance 는 주문 승인 전에 검증을 위해 미리 주문 내역을 저장하는 함수이다.
      */
     public UUID placeOrderInAdvance(OrderFormDto orderFormDto) {
@@ -89,7 +72,7 @@ public class OrderService {
 
         UUID dealProductUuid = orderForm.getDealProductUuid();
 
-        int orderQuantity = orderForm.getOrderQuantity();
+        UUID orderUuid = orderForm.getOrderUuid();
 
         // 1. DB에 존재하는 dealProductUuid 인지
         boolean hasDealProductUuid = dealProductQueryRepository.hasDealProductUuid(dealProductUuid);
@@ -108,11 +91,21 @@ public class OrderService {
         // (1) 재고 조회
         int inventory = inventoryQueryRepository.get(dealProductUuid);
 
-        // (2) 재고 사전 검증
-        orderForm.preValidateOrderQuantityInInventory(inventory);
+        // (2) 실제 주문 가능 수량 계산
+        int realOrderQuantity = orderForm.determineRealOrderQuantity(inventory);
 
-        // (3) 실제 주문 가능 수량 계산
-        int realOrderQuantity = determineRealOrderQuantity(inventory, dealProductUuid, orderForm.getOrderUuid(), orderQuantity, orderForm.getOutOfStockHandlingOption());
+        // (3) 재고 감소
+        int inventoryAfterDecrease = inventoryCommandRepository.decrease(
+                                                                    InventoryIncreaseDecreaseDto.builder()
+                                                                    .dealProductUuid(dealProductUuid)
+                                                                    .orderUuid(orderUuid)
+                                                                    .inventory(realOrderQuantity)
+                                                                    .inventoryEventType(InventoryEventType.ORDER)
+                                                                    .build()
+                                                                );
+
+        // (4) 재고 사후 검증
+        postValidateOrderQuantityInInventory(inventoryAfterDecrease, dealProductUuid, orderUuid, realOrderQuantity);
 
         // 5. 주문 내역 미리 저장
         try {
@@ -129,42 +122,33 @@ public class OrderService {
     }
 
     /**
-     * determineRealOrderQuantity 는 실제 주문 수량을 결정하는 함수 이다.
-     *
-     * realOrderQuantity 이 필요한 이유는 "부분 주문" 때문이다.
-     * 재고량이 0은 아니지만, 사용자가 주문한 수량에 비해 재고량이 없는 경우가 있다.
-     * 이때, 재고량만큼만 주문하도록 할 수 있도록 "부문 주문"이 가능한데, 사용자가 주문한 수량과 혼동되지 않도록 실제 주문하는 수량이라는 의미를 내포하기 위해서 필요하다.
-     *
-     * 트랜잭션 대신 분산락을 사용했던 이유는 https://github.com/f-lab-edu/hee-commerce/pull/135 참고
+     * postValidateOrderQuantityInInventory 는 재고 사후 검증을 하는 함수이다.
      *
      * 분산락 대신 재고 사후 검증 단계를 도입한 이유는 https://github.com/f-lab-edu/hee-commerce/issues/136 참고
-     *
+     * 추가로, 분산락이 필요했던 이유는 https://github.com/f-lab-edu/hee-commerce/pull/135 참고
      */
-    private int determineRealOrderQuantity(int inventory, UUID dealProductUuid, UUID orderUuid, int orderQuantity, OutOfStockHandlingOption outOfStockHandlingOption) {
-        int realOrderQuantity = orderQuantity;
-
-        if(inventory < orderQuantity && outOfStockHandlingOption == OutOfStockHandlingOption.PARTIAL_ORDER) {
-            realOrderQuantity = inventory;
-        }
-        log.debug("realOrderQuantity = {}", realOrderQuantity);
-
-        // 3. 재고 감소
-        int inventoryAfterDecrease = inventoryCommandRepository.decrease(InventoryIncreaseDecreaseDto.builder()
-            .dealProductUuid(dealProductUuid)
-            .orderUuid(orderUuid)
-            .inventory(realOrderQuantity)
-            .inventoryEventType(InventoryEventType.ORDER)
-            .build());
-
-        log.debug("inventoryAfterDecrease = {}", inventoryAfterDecrease);
-
-        // 4. 재고 사후 검증
+    private void postValidateOrderQuantityInInventory(int inventoryAfterDecrease, UUID dealProductUuid, UUID orderUuid, int realOrderQuantity) {
         if(inventoryAfterDecrease < 0) { // 재고 감소가 되지 않아야 되는데, 감소가 된 경우이다. 재고 조회시의 재고량과 실제 감소시킬 떄의 재고량이 달라진 경우에 발생 함.
             rollbackReducedInventory(InventoryEventType.ROLLBACK_BY_POST_VALIDATION_FAILED, dealProductUuid, orderUuid, realOrderQuantity);
             throw new OrderOverStockException();
         }
+    }
 
-        return realOrderQuantity;
+    /**
+     * rollbackReducedInventory 는 임의로 감소시킨 재고량을 다시 원상복귀하기 위한 함수이다.
+     * 함수로 만든 이유는 다양한 원인으로 재고량을 rollback 시켜줘야 하므로, 함수로 만들어 재활용하고 싶었기 때문이다.
+     * @param dealProductUuid : 원상복귀해야 하는 딜 상품 key
+     * @param amount : 원상복귀해야 하는 재고량
+     */
+    private void rollbackReducedInventory(InventoryEventType inventoryEventType, UUID dealProductUuid, UUID orderUuid, int amount) {
+        log.error("[rollback] inventoryEventType = {}, dealProductUuid = {}, orderUuid = {}, amount = {} ", inventoryEventType, dealProductUuid, orderUuid, amount);
+
+        inventoryCommandRepository.increase(InventoryIncreaseDecreaseDto.builder()
+            .dealProductUuid(dealProductUuid)
+            .orderUuid(orderUuid)
+            .inventory(amount)
+            .inventoryEventType(inventoryEventType)
+            .build());
     }
 
     /**

--- a/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
@@ -5,6 +5,7 @@ import com.hcommerce.heecommerce.order.dto.RecipientInfoForm;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.enums.PaymentMethod;
 import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
+import com.hcommerce.heecommerce.order.exception.OrderOverStockException;
 import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
 import java.util.UUID;
 import lombok.Builder;
@@ -73,6 +74,15 @@ public class OrderForm {
     public void validateOrderQuantityInMaxOrderQuantityPerOrder(int maxOrderQuantityPerOrder) {
         if(this.orderQuantity > maxOrderQuantityPerOrder) {
             throw new MaxOrderQuantityExceededException(maxOrderQuantityPerOrder);
+        }
+    }
+
+    /**
+     * preValidateOrderQuantityInInventory 는 주문 수량이 주문 가능한지에 대해 검증하는 함수이다.
+     */
+    public void preValidateOrderQuantityInInventory(int inventory) {
+        if(inventory <= 0 || (this.orderQuantity > inventory && this.outOfStockHandlingOption == OutOfStockHandlingOption.ALL_CANCEL)) {
+            throw new OrderOverStockException();
         }
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
@@ -78,11 +78,23 @@ public class OrderForm {
     }
 
     /**
-     * preValidateOrderQuantityInInventory 는 주문 수량이 주문 가능한지에 대해 검증하는 함수이다.
+     * determineRealOrderQuantity 는 실제 주문 수량을 결정하는 함수 이다.
+     *
+     * realOrderQuantity 이 필요한 이유는 "부분 주문" 때문이다.
+     * 재고량이 0은 아니지만, 사용자가 주문한 수량에 비해 재고량이 없는 경우가 있다.
+     * 이때, 재고량만큼만 주문하도록 할 수 있도록 "부문 주문"이 가능한데, 사용자가 주문한 수량과 혼동되지 않도록 실제 주문하는 수량이라는 의미를 내포하기 위해서 필요하다.
      */
-    public void preValidateOrderQuantityInInventory(int inventory) {
+    public int determineRealOrderQuantity(int inventory) {
         if(inventory <= 0 || (this.orderQuantity > inventory && this.outOfStockHandlingOption == OutOfStockHandlingOption.ALL_CANCEL)) {
             throw new OrderOverStockException();
         }
+
+        int realOrderQuantity = this.orderQuantity;
+
+        if(this.orderQuantity > inventory && this.outOfStockHandlingOption == OutOfStockHandlingOption.PARTIAL_ORDER) {
+            realOrderQuantity = inventory;
+        }
+
+        return realOrderQuantity;
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
@@ -1,0 +1,58 @@
+package com.hcommerce.heecommerce.order.domain;
+
+import com.hcommerce.heecommerce.order.dto.OrderFormDto;
+import com.hcommerce.heecommerce.order.dto.RecipientInfoForm;
+import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
+import com.hcommerce.heecommerce.order.enums.PaymentMethod;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrderForm {
+
+    private final UUID orderUuid;
+
+    private final int userId;
+
+    private final RecipientInfoForm recipientInfoForm;
+
+    private final OutOfStockHandlingOption outOfStockHandlingOption;
+
+    private final UUID dealProductUuid;
+
+    private final int orderQuantity;
+
+    private final PaymentMethod paymentMethod;
+
+    @Builder
+    public OrderForm(
+        UUID orderUuid,
+        int userId,
+        RecipientInfoForm recipientInfoForm,
+        OutOfStockHandlingOption outOfStockHandlingOption,
+        UUID dealProductUuid,
+        int orderQuantity,
+        PaymentMethod paymentMethod
+    ) {
+        this.userId = userId;
+        this.orderUuid = orderUuid;
+        this.recipientInfoForm = recipientInfoForm;
+        this.outOfStockHandlingOption = outOfStockHandlingOption;
+        this.dealProductUuid = dealProductUuid;
+        this.orderQuantity = orderQuantity;
+        this.paymentMethod = paymentMethod;
+    }
+
+    public static OrderForm from(OrderFormDto orderFormDto) {
+        return OrderForm.builder()
+            .userId(orderFormDto.getUserId())
+            .orderUuid(orderFormDto.getOrderUuid())
+            .recipientInfoForm(orderFormDto.getRecipientInfoForm())
+            .outOfStockHandlingOption(orderFormDto.getOutOfStockHandlingOption())
+            .dealProductUuid(orderFormDto.getDealProductUuid())
+            .orderQuantity(orderFormDto.getOrderQuantity())
+            .paymentMethod(orderFormDto.getPaymentMethod())
+            .build();
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
@@ -4,6 +4,7 @@ import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.dto.RecipientInfoForm;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.enums.PaymentMethod;
+import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
 import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
 import java.util.UUID;
 import lombok.Builder;
@@ -63,6 +64,15 @@ public class OrderForm {
     public void validateHasDealProductUuid(boolean hasDealProductUuid) {
         if(!hasDealProductUuid) {
             throw new TimeDealProductNotFoundException(this.dealProductUuid);
+        }
+    }
+
+    /**
+     * validateOrderQuantityInMaxOrderQuantityPerOrder 는 최대 주문 수량에 맞는지에 대해 검증하는 함수이다.
+     */
+    public void validateOrderQuantityInMaxOrderQuantityPerOrder(int maxOrderQuantityPerOrder) {
+        if(this.orderQuantity > maxOrderQuantityPerOrder) {
+            throw new MaxOrderQuantityExceededException(maxOrderQuantityPerOrder);
         }
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
@@ -4,6 +4,7 @@ import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.dto.RecipientInfoForm;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.enums.PaymentMethod;
+import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,5 +55,14 @@ public class OrderForm {
             .orderQuantity(orderFormDto.getOrderQuantity())
             .paymentMethod(orderFormDto.getPaymentMethod())
             .build();
+    }
+
+    /**
+     * validateHasDealProductUuid 는 DB에 존재하는 dealProductUuid 인지 검사하는 함수이다.
+     */
+    public void validateHasDealProductUuid(boolean hasDealProductUuid) {
+        if(!hasDealProductUuid) {
+            throw new TimeDealProductNotFoundException(this.dealProductUuid);
+        }
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/order/dto/OrderFormDto.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/dto/OrderFormDto.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
 
 @Getter
-public class OrderForm {
+public class OrderFormDto {
 
     @NotNull(message = "주문 ID는 필수입니다.")
     private final UUID orderUuid;
@@ -46,7 +46,7 @@ public class OrderForm {
         "orderQuantity",
         "paymentType"
     })
-    public OrderForm(
+    public OrderFormDto(
         UUID orderUuid,
         int userId,
         RecipientInfoForm recipientInfoForm,

--- a/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
+++ b/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
@@ -3,7 +3,7 @@ package com.hcommerce.heecommerce.fixture;
 import com.hcommerce.heecommerce.common.utils.TypeConversionUtils;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderForOrderApproveValidationDto;
-import com.hcommerce.heecommerce.order.dto.OrderForm;
+import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.enums.PaymentMethod;
 import com.hcommerce.heecommerce.order.dto.RecipientInfoForm;
@@ -42,8 +42,8 @@ public class OrderFixture {
     public static final int INVALID_AMOUNT = 1000;
 
     // 주문 사전 저장 Form
-    private static OrderForm.OrderFormBuilder orderFormBuilder() {
-        return OrderForm.builder()
+    private static OrderFormDto.OrderFormDtoBuilder orderFormDtoBuilder() {
+        return OrderFormDto.builder()
             .userId(USER_ID)
             .orderUuid(ORDER_UUID)
             .recipientInfoForm(recipientInfoForm)
@@ -53,13 +53,13 @@ public class OrderFixture {
             .paymentMethod(PaymentMethod.CREDIT_CARD);
     }
 
-    public static final OrderForm orderForm = orderFormBuilder().build();
+    public static final OrderFormDto ORDER_FORM_DTO = orderFormDtoBuilder().build();
 
     /**
      * rebuilder 는 상황에 따라 필드 값을 수정할 수 있도록 하기 위해 만든 함수이다.
      */
-    public static final OrderForm.OrderFormBuilder rebuilder() {
-        return orderFormBuilder();
+    public static final OrderFormDto.OrderFormDtoBuilder rebuilder() {
+        return orderFormDtoBuilder();
     }
 
     // 주문 승인 Form

--- a/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
+++ b/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
@@ -72,6 +72,13 @@ public class OrderFixture {
     /**
      * rebuilder 는 상황에 따라 필드 값을 수정할 수 있도록 하기 위해 만든 함수이다.
      */
+    public static final OrderForm.OrderFormBuilder OrderFormRebuilder() {
+        return orderFormBuilder();
+    }
+
+    /**
+     * rebuilder 는 상황에 따라 필드 값을 수정할 수 있도록 하기 위해 만든 함수이다.
+     */
     public static final OrderFormDto.OrderFormDtoBuilder rebuilder() {
         return orderFormDtoBuilder();
     }

--- a/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
+++ b/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
@@ -1,6 +1,7 @@
 package com.hcommerce.heecommerce.fixture;
 
 import com.hcommerce.heecommerce.common.utils.TypeConversionUtils;
+import com.hcommerce.heecommerce.order.domain.OrderForm;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderForOrderApproveValidationDto;
 import com.hcommerce.heecommerce.order.dto.OrderFormDto;
@@ -54,6 +55,19 @@ public class OrderFixture {
     }
 
     public static final OrderFormDto ORDER_FORM_DTO = orderFormDtoBuilder().build();
+
+    private static OrderForm.OrderFormBuilder orderFormBuilder() {
+        return OrderForm.builder()
+            .userId(USER_ID)
+            .orderUuid(ORDER_UUID)
+            .recipientInfoForm(recipientInfoForm)
+            .outOfStockHandlingOption(OutOfStockHandlingOption.PARTIAL_ORDER)
+            .dealProductUuid(DEAL_PRODUCT_UUID)
+            .orderQuantity(ORDER_QUANTITY)
+            .paymentMethod(PaymentMethod.CREDIT_CARD);
+    }
+
+    public static OrderForm ORDER_FORM = orderFormBuilder().build();
 
     /**
      * rebuilder 는 상황에 따라 필드 값을 수정할 수 있도록 하기 위해 만든 함수이다.

--- a/src/test/java/com/hcommerce/heecommerce/order/OrderControllerTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/OrderControllerTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hcommerce.heecommerce.EnableMockMvc;
 import com.hcommerce.heecommerce.fixture.OrderFixture;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
-import com.hcommerce.heecommerce.order.dto.OrderForm;
+import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.InvalidPaymentAmountException;
 import com.hcommerce.heecommerce.order.exception.OrderOverStockException;
@@ -58,17 +58,17 @@ class OrderControllerTest {
     class Describe_PlaceOrderInAdvance_API {
         @Nested
         @DisplayName("with valid orderForm")
-        class Context_With_Valid_OrderForm {
+        class Context_With_Valid_OrderFormDto {
             @Test
             @DisplayName("returns 201")
             void It_returns_201() throws Exception {
                 // given
                 given(orderService.placeOrderInAdvance(any())).willReturn(UUID.randomUUID());
 
-                OrderForm orderForm = OrderFixture.orderForm;
+                OrderFormDto orderFormDto = OrderFixture.ORDER_FORM_DTO;
 
                 // when
-                String content = objectMapper.writeValueAsString(orderForm);
+                String content = objectMapper.writeValueAsString(orderFormDto);
 
                 ResultActions resultActions = mockMvc.perform(
                     post("/orders/place-in-advance")
@@ -92,7 +92,7 @@ class OrderControllerTest {
 
                 UUID NOT_EXIST_DEAL_PRODUCT_UUID = UUID.randomUUID();
 
-                OrderForm orderFormWithNotExistDealProductUuid = OrderFixture.rebuilder()
+                OrderFormDto orderFormDtoWithNotExistDealProductUuid = OrderFixture.rebuilder()
                     .dealProductUuid(NOT_EXIST_DEAL_PRODUCT_UUID)
                     .build();
 
@@ -101,7 +101,8 @@ class OrderControllerTest {
                     TimeDealProductNotFoundException.class);
 
                 // when
-                String content = objectMapper.writeValueAsString(orderFormWithNotExistDealProductUuid);
+                String content = objectMapper.writeValueAsString(
+                    orderFormDtoWithNotExistDealProductUuid);
 
                 ResultActions resultActions = mockMvc.perform(
                     post("/orders/place-in-advance")
@@ -124,9 +125,9 @@ class OrderControllerTest {
                 // given
                 given(orderService.placeOrderInAdvance(any())).willThrow(OrderOverStockException.class);
 
-                OrderForm orderForm = OrderFixture.orderForm;;
+                OrderFormDto orderFormDto = OrderFixture.ORDER_FORM_DTO;;
 
-                String content = objectMapper.writeValueAsString(orderForm);
+                String content = objectMapper.writeValueAsString(orderFormDto);
 
                 // when
                 ResultActions resultActions = mockMvc.perform(
@@ -154,11 +155,11 @@ class OrderControllerTest {
                     given(orderService.placeOrderInAdvance(any())).willThrow(
                         OrderOverStockException.class);
 
-                    OrderForm orderForm = OrderFixture.rebuilder()
+                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
                                                 .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
                                                 .build();
 
-                    String content = objectMapper.writeValueAsString(orderForm);
+                    String content = objectMapper.writeValueAsString(orderFormDto);
 
                     // when
                     ResultActions resultActions = mockMvc.perform(
@@ -180,13 +181,13 @@ class OrderControllerTest {
                 @DisplayName("returns 201")
                 void It_returns_201() throws Exception {
                     // given
-                    OrderForm orderForm = OrderFixture.rebuilder()
+                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
                                                 .outOfStockHandlingOption(OutOfStockHandlingOption.PARTIAL_ORDER)
                                                 .build();
 
-                    given(orderService.placeOrderInAdvance(orderForm)).willReturn(UUID.randomUUID());
+                    given(orderService.placeOrderInAdvance(orderFormDto)).willReturn(UUID.randomUUID());
 
-                    String content = objectMapper.writeValueAsString(orderForm);
+                    String content = objectMapper.writeValueAsString(orderFormDto);
 
                     // when
                     ResultActions resultActions = mockMvc.perform(
@@ -211,9 +212,9 @@ class OrderControllerTest {
                 // given
                 given(orderService.placeOrderInAdvance(any())).willThrow(OrderOverStockException.class);
 
-                OrderForm orderForm = OrderFixture.orderForm;
+                OrderFormDto orderFormDto = OrderFixture.ORDER_FORM_DTO;
 
-                String content = objectMapper.writeValueAsString(orderForm);
+                String content = objectMapper.writeValueAsString(orderFormDto);
 
                 // when
                 ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/hcommerce/heecommerce/order/OrderServiceTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/OrderServiceTest.java
@@ -18,7 +18,7 @@ import com.hcommerce.heecommerce.inventory.InventoryCommandRepository;
 import com.hcommerce.heecommerce.inventory.InventoryQueryRepository;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderForOrderApproveValidationDto;
-import com.hcommerce.heecommerce.order.dto.OrderForm;
+import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.InvalidPaymentAmountException;
 import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
@@ -78,7 +78,7 @@ class OrderServiceTest {
     class Describe_PlaceOrderInAdvance {
         @Nested
         @DisplayName("with valid orderForm")
-        class Context_With_Valid_OrderForm {
+        class Context_With_Valid_OrderFormDto {
             @Test
             @DisplayName("return OrderUuid")
             void It_returns_OrderUuid() throws InterruptedException {
@@ -96,7 +96,7 @@ class OrderServiceTest {
                 given_when_saveOrderInAdvance_is_success(expectedOrderUuid);
 
                 // when
-                UUID actualUuid = orderService.placeOrderInAdvance(OrderFixture.orderForm);
+                UUID actualUuid = orderService.placeOrderInAdvance(OrderFixture.ORDER_FORM_DTO);
 
                 // then
                 assertEquals(expectedOrderUuid, actualUuid);
@@ -114,7 +114,7 @@ class OrderServiceTest {
 
                 // when + then
                 assertThrows(TimeDealProductNotFoundException.class, () -> {
-                    orderService.placeOrderInAdvance(OrderFixture.orderForm);
+                    orderService.placeOrderInAdvance(OrderFixture.ORDER_FORM_DTO);
                 });
             }
         }
@@ -131,14 +131,14 @@ class OrderServiceTest {
 
                 given_with_maxOrderQuantityPerOrder(OrderFixture.MAX_ORDER_QUANTITY_PER_ORDER);
 
-                OrderForm orderForm = OrderFixture.rebuilder()
+                OrderFormDto orderFormDto = OrderFixture.rebuilder()
                     .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_MAX_ORDER_QUANTITY_PER_ORDER)
                     .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
                     .build();
 
                 // when + then
                 assertThrows(MaxOrderQuantityExceededException.class, () -> {
-                    orderService.placeOrderInAdvance(orderForm);
+                    orderService.placeOrderInAdvance(orderFormDto);
                 });
             }
         }
@@ -158,14 +158,14 @@ class OrderServiceTest {
 
                     given_with_inventory(OrderFixture.INVENTORY);
 
-                    OrderForm orderForm = OrderFixture.rebuilder()
+                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
                         .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
                         .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
                         .build();
 
                     // when + then
                     assertThrows(OrderOverStockException.class, () -> {
-                        orderService.placeOrderInAdvance(orderForm);
+                        orderService.placeOrderInAdvance(orderFormDto);
                     });
                 }
             }
@@ -188,14 +188,14 @@ class OrderServiceTest {
 
                     given_when_saveOrderInAdvance_is_success(uuidFixture);
 
-                    OrderForm orderForm = OrderFixture.rebuilder()
+                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
                         .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
                         .outOfStockHandlingOption(OutOfStockHandlingOption.PARTIAL_ORDER)
                         .build();
 
                     // when + then
                     assertDoesNotThrow(() -> {
-                        orderService.placeOrderInAdvance(orderForm);
+                        orderService.placeOrderInAdvance(orderFormDto);
                     });
                 }
             }
@@ -218,13 +218,13 @@ class OrderServiceTest {
 
                 UUID ROLLBACK_NEEDED_DEAL_PRODUCT_UUID = UUID.randomUUID();
 
-                OrderForm orderForm = OrderFixture.rebuilder()
+                OrderFormDto orderFormDto = OrderFixture.rebuilder()
                     .dealProductUuid(ROLLBACK_NEEDED_DEAL_PRODUCT_UUID)
                     .build();
 
                 // when
                 assertThrows(OrderOverStockException.class, () -> {
-                    orderService.placeOrderInAdvance(orderForm);
+                    orderService.placeOrderInAdvance(orderFormDto);
                 });
 
                 verify(inventoryCommandRepository).increase(any());

--- a/src/test/java/com/hcommerce/heecommerce/order/domain/OrderFormTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/domain/OrderFormTest.java
@@ -1,0 +1,50 @@
+package com.hcommerce.heecommerce.order.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hcommerce.heecommerce.fixture.OrderFixture;
+import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OrderForm")
+class OrderFormTest {
+
+    @Nested
+    @DisplayName("validateHasDealProductUuid")
+    class Describe_ValidateHasDealProductUuid {
+        @Nested
+        @DisplayName("when hasDealProductUuid is true")
+        class Context_When_HasDealProductUuid_Is_True {
+            @Test
+            @DisplayName("does not throws TimeDealProductNotFoundException")
+            void It_Does_Not_Throws_TimeDealProductNotFoundException() {
+                OrderForm orderForm = OrderFixture.ORDER_FORM;
+
+                assertDoesNotThrow(() -> {
+                    boolean hasDealProductUuid = true;
+
+                    orderForm.validateHasDealProductUuid(hasDealProductUuid);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("when hasDealProductUuid is false")
+        class Context_When_HasDealProductUuid_Is_False {
+            @Test
+            @DisplayName("throws TimeDealProductNotFoundException")
+            void It_throws_TimeDealProductNotFoundException() {
+                OrderForm orderForm = OrderFixture.ORDER_FORM;
+
+                assertThrows(TimeDealProductNotFoundException.class, () -> {
+                    boolean hasDealProductUuid = false;
+
+                    orderForm.validateHasDealProductUuid(hasDealProductUuid);
+                });
+            }
+        }
+    }
+}

--- a/src/test/java/com/hcommerce/heecommerce/order/domain/OrderFormTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/domain/OrderFormTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hcommerce.heecommerce.fixture.OrderFixture;
+import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
+import com.hcommerce.heecommerce.order.exception.OrderOverStockException;
 import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -82,6 +84,61 @@ class OrderFormTest {
                     int maxOrderQuantityPerOrder = OrderFixture.MAX_ORDER_QUANTITY_PER_ORDER;
 
                     orderForm.validateOrderQuantityInMaxOrderQuantityPerOrder(maxOrderQuantityPerOrder);
+                });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("preValidateOrderQuantityInInventory")
+    class Describe_PreValidateOrderQuantityInInventory {
+        @Nested
+        @DisplayName("with inventory > 0")
+        class Context_With_inventory_Is_More_Than_0 {
+            @Test
+            @DisplayName("does not throws OrderOverStockException")
+            void It_Does_Not_Throws_OrderOverStockException() {
+                OrderForm orderForm = OrderFixture.ORDER_FORM;
+
+                assertDoesNotThrow(() -> {
+                    int inventory = OrderFixture.INVENTORY;
+
+                    orderForm.preValidateOrderQuantityInInventory(inventory);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("with inventory <= 0")
+        class Context_With_inventory_Is_Less_Than_0 {
+            @Test
+            @DisplayName("throws OrderOverStockException")
+            void It_throws_OrderOverStockException() {
+                OrderForm orderForm = OrderFixture.ORDER_FORM;
+
+                assertThrows(OrderOverStockException.class, () -> {
+                    int inventory = 0;
+
+                    orderForm.preValidateOrderQuantityInInventory(inventory);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("with this.orderQuantity > inventory and this.outOfStockHandlingOption == OutOfStockHandlingOption.ALL_CANCEL")
+        class Context_With_orderQuantity_Is_More_Than_Inventory_AND_OutOfStockHandlingOption_Is_ALL_CANCEL {
+            @Test
+            @DisplayName("throws OrderOverStockException")
+            void It_throws_MaxOrderQuantityExceededException() {
+                OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                    .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
+                    .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
+                    .build();
+
+                assertThrows(OrderOverStockException.class, () -> {
+                    int inventory = OrderFixture.INVENTORY;
+
+                    orderForm.preValidateOrderQuantityInInventory(inventory);
                 });
             }
         }

--- a/src/test/java/com/hcommerce/heecommerce/order/domain/OrderFormTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/domain/OrderFormTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hcommerce.heecommerce.fixture.OrderFixture;
+import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
 import com.hcommerce.heecommerce.order.exception.TimeDealProductNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,6 +44,44 @@ class OrderFormTest {
                     boolean hasDealProductUuid = false;
 
                     orderForm.validateHasDealProductUuid(hasDealProductUuid);
+                });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("validateOrderQuantityInMaxOrderQuantityPerOrder")
+    class Describe_ValidateOrderQuantityInMaxOrderQuantityPerOrder {
+        @Nested
+        @DisplayName("with orderQuantity < maxOrderQuantityPerOrder")
+        class Context_With_orderQuantity_Is_Less_Than_MaxOrderQuantityPerOrder {
+            @Test
+            @DisplayName("does not throws MaxOrderQuantityExceededException")
+            void It_Does_Not_Throws_MaxOrderQuantityExceededException() {
+                OrderForm orderForm = OrderFixture.ORDER_FORM;
+
+                assertDoesNotThrow(() -> {
+                    int maxOrderQuantityPerOrder = OrderFixture.MAX_ORDER_QUANTITY_PER_ORDER;
+
+                    orderForm.validateOrderQuantityInMaxOrderQuantityPerOrder(maxOrderQuantityPerOrder);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("with orderQuantity > maxOrderQuantityPerOrder")
+        class Context_With_orderQuantity_Is_More_Than_MaxOrderQuantityPerOrder {
+            @Test
+            @DisplayName("throws MaxOrderQuantityExceededException")
+            void It_throws_MaxOrderQuantityExceededException() {
+                OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                    .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_MAX_ORDER_QUANTITY_PER_ORDER)
+                    .build();
+
+                assertThrows(MaxOrderQuantityExceededException.class, () -> {
+                    int maxOrderQuantityPerOrder = OrderFixture.MAX_ORDER_QUANTITY_PER_ORDER;
+
+                    orderForm.validateOrderQuantityInMaxOrderQuantityPerOrder(maxOrderQuantityPerOrder);
                 });
             }
         }


### PR DESCRIPTION
# Why

- `주문 사정 저장`에 대한 OrderService의 책임이 너무 많다보니, OrderService의 `placeOrderInAdvance`애 사용되는 private 함수가 많아져서,  다음과 같은 불편함을 해결하고자, `OrderForm`이라는 `도메인 모델`을 만들어서 리팩토링 했습니다. `private -> public 으로 바꿀까? `했는데, 그러면 `캡슐화` 관점에서 너무 많은 함수들이 노출되어서 좋지 않는 방법이라고 생각하여, 도메인 모델 하나 만들어서 거기서 관리하자 라는 생각을 하였습니다.

#### 불편함 1. private 함수 너무 많아서, 가독성이 좋지 않았습니다.
#### 불편함 2. private 함수이다보니, 테스트 코드 작성하는 것이 어려웠습니다. 
 - `비즈니스 로직`을 `테스트 코드`로 문서화 하고 싶었는데, 비즈니스 로직이 대부분 private 함수 내에 있어서, 테스트 코드 작성하는데 어려움이 있었습니다. 공부해본 결과, 리플렉션으로 private 함수를 테스트 할 수 있다고 하지만, 리플랙션 사용은 지양하는 것이 좋고, 만약 private를 테스트 하고 싶으면, 그건 `클래스로 분리하라는 신호`라는 글을 보고, 도메인 모델 클래스 만들어서 해결하면 되겠다라는 생각을 했습니다.
#### 불편함 3. private 함수이다보니, 로그 AOP 적용이 어려웠습니다. 
- 로그 추적 AOP 만들어서 함수 호출 흐름 파악하고 싶었는데, private 함수라 적용이 안되었습니다. 물론 리플랙션을 사용해서 private에도 AOP를 적용시킬 수 있지만, 리플랙션 사용은 지양하는 것이 좋아서, 리플랙션을 사용하지 않았습니다.



# What
- `OrderForm` 이라는 도메인 모델을 만들어서 OrderService의 `placeOrderInAdvance`의 일부 로직에 대한 책임을 부여하고, `OrderForm`의 단위테스트를 작성하여 비즈니스 로직을 문서화 할 수 있도록 함.

1. 객체의 역할을 좀더 명확히 하기 위해 `OrderForm` -> `OrderFormDto`로 이름 변경
2. `OrderService`에서 `OrderFormDto` 대신 `OrderForm` 사용하기
4. `validateHasDealProductUuid` 책임을 `OrderService` -> `OrderForm` 으로 수정
5. `validateOrderQuantityInMaxOrderQuantityPerOrder` 책임을 `OrderService` -> `OrderForm`
10. `preValidateOrderQuantityInInventory` 책임을 `OrderService` -> `OrderForm` 으로 수정
11. `determineRealOrderQuantity` 책임을 `OrderService` -> `OrderForm` 으로 수정
 
