### PR TITLE
혼동을 줄이기 위해 `orderService`의 `placeOrderInAdvance`의 매개변수를 `orderFormDto` -> `orderForm`로 변경

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
@@ -1,6 +1,7 @@
 package com.hcommerce.heecommerce.order;
 
 import com.hcommerce.heecommerce.common.dto.ResponseDto;
+import com.hcommerce.heecommerce.order.domain.OrderForm;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.dto.OrderUuid;
@@ -32,7 +33,9 @@ public class OrderController {
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseDto placeOrderInAdvance(@Valid @RequestBody OrderFormDto orderFormDto) {
 
-        UUID orderUuid = orderService.placeOrderInAdvance(orderFormDto);
+        OrderForm orderForm = OrderForm.of(orderFormDto, 1); // TODO : 임의 데이터 넣어줌. auth 완성 후 수정 예정
+
+        UUID orderUuid = orderService.placeOrderInAdvance(orderForm);
 
         return ResponseDto.builder()
             .code(HttpStatus.CREATED.name())

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderService.java
@@ -15,7 +15,6 @@ import com.hcommerce.heecommerce.order.domain.OrderForm;
 import com.hcommerce.heecommerce.order.dto.OrderAfterApproveDto;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderForOrderApproveValidationDto;
-import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.entity.OrderFormSavedInAdvanceEntity;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.InvalidPaymentAmountException;
@@ -72,9 +71,7 @@ public class OrderService {
     /**
      * placeOrderInAdvance 는 주문 승인 전에 검증을 위해 미리 주문 내역을 저장하는 함수이다.
      */
-    public UUID placeOrderInAdvance(OrderFormDto orderFormDto) {
-        OrderForm orderForm = OrderForm.from(orderFormDto);
-
+    public UUID placeOrderInAdvance(OrderForm orderForm) {
         UUID dealProductUuid = orderForm.getDealProductUuid();
 
         UUID orderUuid = orderForm.getOrderUuid();

--- a/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/domain/OrderForm.java
@@ -48,9 +48,9 @@ public class OrderForm {
         this.paymentMethod = paymentMethod;
     }
 
-    public static OrderForm from(OrderFormDto orderFormDto) {
+    public static OrderForm of(OrderFormDto orderFormDto, int userId) {
         return OrderForm.builder()
-            .userId(orderFormDto.getUserId())
+            .userId(userId)
             .orderUuid(orderFormDto.getOrderUuid())
             .recipientInfoForm(orderFormDto.getRecipientInfoForm())
             .outOfStockHandlingOption(orderFormDto.getOutOfStockHandlingOption())

--- a/src/test/java/com/hcommerce/heecommerce/order/OrderControllerTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/OrderControllerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hcommerce.heecommerce.EnableMockMvc;
 import com.hcommerce.heecommerce.fixture.OrderFixture;
 import com.hcommerce.heecommerce.fixture.UserFixture;
+import com.hcommerce.heecommerce.order.domain.OrderForm;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
@@ -213,13 +214,14 @@ class OrderControllerTest {
                 @DisplayName("returns 201")
                 void It_returns_201() throws Exception {
                     // given
-                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
+                    OrderForm orderForm = OrderFixture.OrderFormRebuilder()
                                                 .outOfStockHandlingOption(OutOfStockHandlingOption.PARTIAL_ORDER)
                                                 .build();
 
-                    given(orderService.placeOrderInAdvance(orderFormDto)).willReturn(UUID.randomUUID());
 
-                    String content = objectMapper.writeValueAsString(orderFormDto);
+                    given(orderService.placeOrderInAdvance(orderForm)).willReturn(UUID.randomUUID());
+
+                    String content = objectMapper.writeValueAsString(orderForm);
 
                     // when
                     ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/hcommerce/heecommerce/order/OrderServiceTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/OrderServiceTest.java
@@ -17,9 +17,9 @@ import com.hcommerce.heecommerce.fixture.OrderFixture;
 import com.hcommerce.heecommerce.fixture.TossConfirmResponse;
 import com.hcommerce.heecommerce.inventory.InventoryCommandRepository;
 import com.hcommerce.heecommerce.inventory.InventoryQueryRepository;
+import com.hcommerce.heecommerce.order.domain.OrderForm;
 import com.hcommerce.heecommerce.order.dto.OrderApproveForm;
 import com.hcommerce.heecommerce.order.dto.OrderForOrderApproveValidationDto;
-import com.hcommerce.heecommerce.order.dto.OrderFormDto;
 import com.hcommerce.heecommerce.order.enums.OutOfStockHandlingOption;
 import com.hcommerce.heecommerce.order.exception.InvalidPaymentAmountException;
 import com.hcommerce.heecommerce.order.exception.MaxOrderQuantityExceededException;
@@ -104,7 +104,7 @@ class OrderServiceTest {
                 given_when_saveOrderInAdvance_is_success(expectedOrderUuid);
 
                 // when
-                UUID actualUuid = orderService.placeOrderInAdvance(OrderFixture.ORDER_FORM_DTO);
+                UUID actualUuid = orderService.placeOrderInAdvance(OrderFixture.ORDER_FORM);
 
                 // then
                 assertEquals(expectedOrderUuid, actualUuid);
@@ -122,7 +122,7 @@ class OrderServiceTest {
 
                 // when + then
                 assertThrows(TimeDealProductNotFoundException.class, () -> {
-                    orderService.placeOrderInAdvance(OrderFixture.ORDER_FORM_DTO);
+                    orderService.placeOrderInAdvance(OrderFixture.ORDER_FORM);
                 });
             }
         }
@@ -138,13 +138,13 @@ class OrderServiceTest {
 
                 given_with_invalid_userId();
 
-                OrderFormDto orderFormDto = OrderFixture.rebuilder()
-                                                .userId(0)
-                                                .build();
+                OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                                            .userId(0)
+                                            .build();
 
                 // when + then
                 assertThrows(UserNotFoundException.class, () -> {
-                    orderService.placeOrderInAdvance(orderFormDto);
+                    orderService.placeOrderInAdvance(orderForm);
                 });
             }
         }
@@ -163,14 +163,14 @@ class OrderServiceTest {
 
                 given_with_maxOrderQuantityPerOrder(OrderFixture.MAX_ORDER_QUANTITY_PER_ORDER);
 
-                OrderFormDto orderFormDto = OrderFixture.rebuilder()
-                    .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_MAX_ORDER_QUANTITY_PER_ORDER)
-                    .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
-                    .build();
+                OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                                            .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_MAX_ORDER_QUANTITY_PER_ORDER)
+                                            .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
+                                            .build();
 
                 // when + then
                 assertThrows(MaxOrderQuantityExceededException.class, () -> {
-                    orderService.placeOrderInAdvance(orderFormDto);
+                    orderService.placeOrderInAdvance(orderForm);
                 });
             }
         }
@@ -192,14 +192,14 @@ class OrderServiceTest {
 
                     given_with_inventory(OrderFixture.INVENTORY);
 
-                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
-                        .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
-                        .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
-                        .build();
+                    OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                                                .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
+                                                .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
+                                                .build();
 
                     // when + then
                     assertThrows(OrderOverStockException.class, () -> {
-                        orderService.placeOrderInAdvance(orderFormDto);
+                        orderService.placeOrderInAdvance(orderForm);
                     });
                 }
             }
@@ -224,14 +224,14 @@ class OrderServiceTest {
 
                     given_when_saveOrderInAdvance_is_success(uuidFixture);
 
-                    OrderFormDto orderFormDto = OrderFixture.rebuilder()
-                        .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
-                        .outOfStockHandlingOption(OutOfStockHandlingOption.PARTIAL_ORDER)
-                        .build();
+                    OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                                                .orderQuantity(OrderFixture.ORDER_QUANTITY_OVER_INVENTORY)
+                                                .outOfStockHandlingOption(OutOfStockHandlingOption.PARTIAL_ORDER)
+                                                .build();
 
                     // when + then
                     assertDoesNotThrow(() -> {
-                        orderService.placeOrderInAdvance(orderFormDto);
+                        orderService.placeOrderInAdvance(orderForm);
                     });
                 }
             }
@@ -256,13 +256,13 @@ class OrderServiceTest {
 
                 UUID ROLLBACK_NEEDED_DEAL_PRODUCT_UUID = UUID.randomUUID();
 
-                OrderFormDto orderFormDto = OrderFixture.rebuilder()
-                    .dealProductUuid(ROLLBACK_NEEDED_DEAL_PRODUCT_UUID)
-                    .build();
+                OrderForm orderForm = OrderFixture.OrderFormRebuilder()
+                                            .dealProductUuid(ROLLBACK_NEEDED_DEAL_PRODUCT_UUID)
+                                            .build();
 
                 // when
                 assertThrows(OrderOverStockException.class, () -> {
-                    orderService.placeOrderInAdvance(orderFormDto);
+                    orderService.placeOrderInAdvance(orderForm);
                 });
 
                 verify(inventoryCommandRepository).increase(any());


### PR DESCRIPTION
# Why
 - placeOrderInAdvance 내에서 `orderFormDto`를 가지고, `orderForm`을 만들어 내는데, `orderFormDto`와 `orderForm` 둘다 있으니, 값을 사용할 떄, `orderForm`에서 뽑아서 사용해야되는데, `orderFormDto`에서 뽑아서 사용할 우려가 있으므로, 혼동을 줄이기 위해 수정
