### PR TITLE
`의존성 주입`을 활용하여 `Authentication` 관련 코드 유연성 향상

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/auth/AuthConfig.java
+++ b/src/main/java/com/hcommerce/heecommerce/auth/AuthConfig.java
@@ -1,0 +1,21 @@
+package com.hcommerce.heecommerce.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AuthConfig {
+
+    private final JwtAuthHelper jwtAuthHelper;
+
+    @Autowired
+    public AuthConfig(JwtAuthHelper jwtAuthHelper) {
+        this.jwtAuthHelper = jwtAuthHelper;
+    }
+
+    @Bean
+    public AuthHelper authHelper() {
+        return jwtAuthHelper; // TODO : 추후에 세션으로 관리하는 걸로 바뀌면 이곳 수정해줘야 함.
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/auth/AuthHelper.java
+++ b/src/main/java/com/hcommerce/heecommerce/auth/AuthHelper.java
@@ -1,0 +1,11 @@
+package com.hcommerce.heecommerce.auth;
+
+import com.hcommerce.heecommerce.user.UserQueryRepository;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface AuthHelper {
+
+    boolean isAuthenticatedUser(HttpServletRequest request, UserQueryRepository userQueryRepository);
+
+    AuthUserInfo getAuthUserInfo(String authInfo);
+}

--- a/src/main/java/com/hcommerce/heecommerce/auth/AuthenticationService.java
+++ b/src/main/java/com/hcommerce/heecommerce/auth/AuthenticationService.java
@@ -1,65 +1,42 @@
 package com.hcommerce.heecommerce.auth;
 
-import com.hcommerce.heecommerce.common.utils.JwtUtils;
 import com.hcommerce.heecommerce.user.UserQueryRepository;
-import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+
+/**
+ * AuthHelper
+ * - isAuthenticatedUser
+ * - getAuthUserInfo
+ *
+ * JwtAuthHelper
+ *
+ * SessionAuthHelper
+ *
+ */
 @Service
 public class AuthenticationService {
 
-    private final String AUTH_TYPE = "Bearer";
-
-    private final JwtUtils jwtUtils;
-
     private final UserQueryRepository userQueryRepository;
 
-    @Autowired
-    public AuthenticationService(JwtUtils jwtUtils, UserQueryRepository userQueryRepository) {
-        this.jwtUtils = jwtUtils;
-        this.userQueryRepository = userQueryRepository;
-    }
+    private final AuthHelper authHelper;
 
-    // TODO : 테스트용으로 일단 간단하게 구현함.
-    public String login(int userId) {
-        return jwtUtils.encode(userId);
+    @Autowired
+    public AuthenticationService(
+        UserQueryRepository userQueryRepository,
+        AuthHelper authHelper
+    ) {
+        this.userQueryRepository = userQueryRepository;
+        this.authHelper = authHelper;
     }
 
     /**
      * isAuthenticatedUser는 HTTP 요청이 인증된 사용자에 의한 것인지를 판단하는 함수이다.
      */
     public boolean isAuthenticatedUser(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization");
-
-        if(authorization == null || authorization.isBlank()) {
-            return false;
-        }
-
-        if(!isValidAuthType(authorization)) {
-            return false;
-        }
-
-        String accessToken = extractAccessToken(authorization);
-
-        if(accessToken == null || accessToken.isBlank()) {
-            return false;
-        }
-
-        AuthUserInfo authUserInfo = parseAccessToken(accessToken);
-
-        if(authUserInfo == null) {
-            return false;
-        }
-
-        boolean hasUserId = userQueryRepository.hasUserId(authUserInfo.getUserId());
-
-        if(!hasUserId) {
-            return false;
-        }
-
-        return true;
+        return authHelper.isAuthenticatedUser(request, userQueryRepository);
     }
 
     /**
@@ -67,52 +44,7 @@ public class AuthenticationService {
      * 각 단계별로 유효성 검사를 할 수 있겠지만, 다른 기능 구현에 집중하기 위해 시간 관계상
      * AuthInterceptor 에서 authorization 의 유효성이 모두 유효하게 판단된 상황을 가정해서 따로 추가하지 않았다.
      */
-    public AuthUserInfo parseAuthorization(String authorization) {
-        String accessToken = extractAccessToken(authorization);
-
-        AuthUserInfo authUserInfo = parseAccessToken(accessToken);
-
-        return authUserInfo;
-    }
-
-    /**
-     * isValidAuthType 는 HTTP Header 의 authorization 의 인증 유형이 유효한 인증 유형인지를 판단하는 함수이다.
-     */
-    private boolean isValidAuthType(String authorization) {
-        return authorization.startsWith(AUTH_TYPE);
-    }
-
-    /**
-     * isValidAuthType 는 HTTP Header 의 authorization로부터 accessToken을 추춣하는 함수이다.
-     */
-    private String extractAccessToken(String authorization) {
-        String[] authorizationUnit = authorization.split(AUTH_TYPE+" ");
-
-        if(authorizationUnit.length < 2) {
-            return null;
-        }
-
-        String accessToken = authorizationUnit[1];
-
-        if(accessToken.isBlank()) {
-            return null;
-        }
-
-        return accessToken;
-    }
-
-    /**
-     * parseAccessToken 는 accessToken에 파싱하여 저장된 사용자 인증 정보를 리턴하는 함수이다.
-     */
-    private AuthUserInfo parseAccessToken(String accessToken) {
-        Claims claims = jwtUtils.decode(accessToken);
-
-        if(claims == null) {
-            return null;
-        }
-
-        int userId = claims.get("userId", Integer.class);
-
-        return new AuthUserInfo(userId);
+    public AuthUserInfo getAuthUserInfo(String authInfo) {
+        return authHelper.getAuthUserInfo(authInfo);
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/auth/JwtAuthHelper.java
+++ b/src/main/java/com/hcommerce/heecommerce/auth/JwtAuthHelper.java
@@ -1,0 +1,113 @@
+package com.hcommerce.heecommerce.auth;
+
+import com.hcommerce.heecommerce.common.utils.JwtUtils;
+import com.hcommerce.heecommerce.user.UserQueryRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthHelper implements AuthHelper {
+
+    private final String AUTH_TYPE = "Bearer";
+
+    private final JwtUtils jwtUtils;
+
+    @Autowired
+    public JwtAuthHelper(JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+
+
+    /**
+     * isAuthenticatedUser는 HTTP 요청이 인증된 사용자에 의한 것인지를 판단하는 함수이다.
+     */
+    @Override
+    public boolean isAuthenticatedUser(HttpServletRequest request, UserQueryRepository userQueryRepository) {
+        String authorization = request.getHeader("Authorization");
+
+        if(authorization == null || authorization.isBlank()) {
+            return false;
+        }
+
+        if(!isValidAuthType(authorization)) {
+            return false;
+        }
+
+        String accessToken = extractAccessToken(authorization);
+
+        if(accessToken == null || accessToken.isBlank()) {
+            return false;
+        }
+
+        AuthUserInfo authUserInfo = parseAccessToken(accessToken);
+
+        if(authUserInfo == null) {
+            return false;
+        }
+
+        boolean hasUserId = userQueryRepository.hasUserId(authUserInfo.getUserId());
+
+        if(!hasUserId) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * getAuthUserInfo 는 HTTP Header 의 authorization 를 피상해서 accessToken에 담긴 정보를 리턴하는 함수이다.
+     * 각 단계별로 유효성 검사를 할 수 있겠지만, 다른 기능 구현에 집중하기 위해 시간 관계상
+     * AuthInterceptor 에서 authorization 의 유효성이 모두 유효하게 판단된 상황을 가정해서 따로 추가하지 않았다.
+     */
+    @Override
+    public AuthUserInfo getAuthUserInfo(String auth) {
+        String accessToken = extractAccessToken(auth);
+
+        AuthUserInfo authUserInfo = parseAccessToken(accessToken);
+
+        return authUserInfo;
+    }
+
+    /**
+     * isValidAuthType 는 HTTP Header 의 authorization 의 인증 유형이 유효한 인증 유형인지를 판단하는 함수이다.
+     */
+    private boolean isValidAuthType(String authorization) {
+        return authorization.startsWith(AUTH_TYPE);
+    }
+
+    /**
+     * isValidAuthType 는 HTTP Header 의 authorization로부터 accessToken을 추춣하는 함수이다.
+     */
+    private String extractAccessToken(String authorization) {
+        String[] authorizationUnit = authorization.split(AUTH_TYPE+" ");
+
+        if(authorizationUnit.length < 2) {
+            return null;
+        }
+
+        String accessToken = authorizationUnit[1];
+
+        if(accessToken.isBlank()) {
+            return null;
+        }
+
+        return accessToken;
+    }
+
+    /**
+     * parseAccessToken 는 accessToken에 파싱하여 저장된 사용자 인증 정보를 리턴하는 함수이다.
+     */
+    private AuthUserInfo parseAccessToken(String accessToken) {
+        Claims claims = jwtUtils.decode(accessToken);
+
+        if(claims == null) {
+            return null;
+        }
+
+        int userId = claims.get("userId", Integer.class);
+
+        return new AuthUserInfo(userId);
+    }
+}

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
@@ -41,7 +41,7 @@ public class OrderController {
         @RequestHeader(value = "Authorization") String authorization,
         @Valid @RequestBody OrderFormDto orderFormDto
     ) {
-        AuthUserInfo authUserInfo = authenticationService.parseAuthorization(authorization);
+        AuthUserInfo authUserInfo = authenticationService.getAuthUserInfo(authorization);
 
         OrderForm orderForm = OrderForm.of(orderFormDto, authUserInfo.getUserId());
 

--- a/src/test/java/com/hcommerce/heecommerce/auth/JwtAuthHelperTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/auth/JwtAuthHelperTest.java
@@ -1,0 +1,181 @@
+package com.hcommerce.heecommerce.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+import com.hcommerce.heecommerce.common.utils.JwtUtils;
+import com.hcommerce.heecommerce.fixture.AuthFixture;
+import com.hcommerce.heecommerce.fixture.JwtFixture;
+import com.hcommerce.heecommerce.fixture.UserFixture;
+import com.hcommerce.heecommerce.user.UserQueryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+@DisplayName("JwtAuthHelper")
+class JwtAuthHelperTest {
+
+    @Mock
+    private JwtUtils jwtUtils;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @InjectMocks
+    private JwtAuthHelper jwtAuthHelper;
+
+    @Mock
+    private UserQueryRepository userQueryRepository;
+
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        request = new MockHttpServletRequest();
+    }
+
+    @Nested
+    @DisplayName("isAuthenticatedUser")
+    class Describe_IsAuthenticatedUser {
+        @Nested
+        @DisplayName("with valid authorization")
+        class Context_With_Valid_Authorization {
+            @Test
+            @DisplayName("returns true")
+            void It_returns_true() {
+                // given
+                request.addHeader("Authorization", AuthFixture.AUTHORIZATION);
+
+                given(jwtUtils.decode(any())).willReturn(JwtFixture.CLAIMS);
+
+                given(userQueryRepository.hasUserId(anyInt())).willReturn(true);
+
+                // when
+                boolean result = jwtAuthHelper.isAuthenticatedUser(request, userQueryRepository);
+
+                // then
+                assertTrue(result);
+            }
+        }
+
+        @Nested
+        @DisplayName("when authorization is empty")
+        class Context_When_Authorization_Is_Empty {
+            @Test
+            @DisplayName("returns false")
+            void It_returns_false() {
+                // given
+                request.addHeader("Authorization", "");
+
+                given(jwtUtils.decode(any())).willReturn(JwtFixture.CLAIMS);
+
+                given(userQueryRepository.hasUserId(anyInt())).willReturn(true);
+
+                // when
+                boolean result = jwtAuthHelper.isAuthenticatedUser(request, userQueryRepository);
+
+                // then
+                assertFalse(result);
+            }
+        }
+
+        @Nested
+        @DisplayName("with invalid authType")
+        class Context_With_Invalid_AuthType {
+            @Test
+            @DisplayName("returns false")
+            void It_returns_false() {
+                // given
+                request.addHeader("Authorization", AuthFixture.AUTHORIZATION_WITH_INVALID_AUTH_TYPE);
+
+                // when
+                boolean result = jwtAuthHelper.isAuthenticatedUser(request, userQueryRepository);
+
+                // then
+                assertFalse(result);
+            }
+        }
+
+        // accessToken
+        @Nested
+        @DisplayName("with invalid accessToken")
+        class Context_With_Invalid_AccessToken {
+            @Test
+            @DisplayName("returns false")
+            void It_returns_false() {
+                // given
+                request.addHeader("Authorization", AuthFixture.AUTHORIZATION_WITHOUT_TOKEN);
+
+                // when
+                boolean result = jwtAuthHelper.isAuthenticatedUser(request, userQueryRepository);
+
+                // then
+                assertFalse(result);
+            }
+        }
+
+        @Nested
+        @DisplayName("with invalid authUserInfo")
+        class Context_With_Invalid_AuthUserInfo {
+            @Test
+            @DisplayName("returns false")
+            void It_returns_false() {
+                // given
+                request.addHeader("Authorization", AuthFixture.AUTHORIZATION_WITHOUT_TOKEN_PAYLOAD);
+
+                given(jwtUtils.decode(any())).willReturn(null);
+
+                // when
+                boolean result = jwtAuthHelper.isAuthenticatedUser(request, userQueryRepository);
+
+                // then
+                assertFalse(result);
+            }
+        }
+        // authUserInfo
+
+        @Nested
+        @DisplayName("with invalid userId")
+        class Context_With_Invalid_UserId {
+            @Test
+            @DisplayName("returns true")
+            void It_returns_true() {
+                // given
+                request.addHeader("Authorization", AuthFixture.AUTHORIZATION);
+
+                given(jwtUtils.decode(any())).willReturn(JwtFixture.CLAIMS);
+
+                given(userQueryRepository.hasUserId(anyInt())).willReturn(false);
+
+                // when
+                boolean result = jwtAuthHelper.isAuthenticatedUser(request, userQueryRepository);
+
+                // then
+                assertFalse(result);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getAuthUserInfo")
+    class Describe_GetAuthUserInfo {
+        @Test
+        @DisplayName("returns tokenPayload with `userId`")
+        void It_returns_TokenPayload() {
+            given(jwtUtils.decode(any())).willReturn(JwtFixture.CLAIMS);
+
+            AuthUserInfo authUserInfo = jwtAuthHelper.getAuthUserInfo(AuthFixture.AUTHORIZATION);
+
+            assertEquals(authUserInfo.getUserId(), UserFixture.ID);
+        }
+    }
+}


### PR DESCRIPTION
# What
1. `AuthHelper 인터페이스`와 `의존성 주입`을 활용하여 코드 유연성 향상
2. parseAuthorization -> getAuthUserInfo 네이밍 수정 : 좀더 범용적으로 사용할 수 있는 것 같아서

# Why
1. 인가 기능을 JWT 를 활용해서 할까, Redis를 세션 저장소로 활용해서 할까? 고민하다가 각각의 장단점을 좀더 살펴보면서 추후에 결정하고 싶고, 다른 작업이 더 우선순위라고 생각해서, 일단 둘다 대응할 수 있는 유연한 코드를 만듬. 
2. 좀더 범용적으로 사용할 수 있는 것 같아서


