### PR TITLE
`재고 감소`을 `주문 사전 저장` 단계 -> `주문 승인` 완료 후에 이루어지도록 수정

### DIFF
--- a/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
+++ b/src/test/java/com/hcommerce/heecommerce/fixture/OrderFixture.java
@@ -40,7 +40,10 @@ public class OrderFixture {
 
     public static final int INVALID_INVENTORY_AFTER_DECREASE = -1;
 
+    public static final int AMOUNT = 15000;
     public static final int INVALID_AMOUNT = 1000;
+
+
 
     // 주문 사전 저장 Form
     private static OrderFormDto.OrderFormDtoBuilder orderFormDtoBuilder() {
@@ -86,7 +89,7 @@ public class OrderFixture {
     private static OrderApproveForm.OrderApproveFormBuilder orderApproveFormBuilder() {
         return OrderApproveForm.builder()
             .orderId(ORDER_UUID.toString())
-            .amount(15000)
+            .amount(AMOUNT)
             .paymentKey("tossPaymentsPaymentKey");
     }
 
@@ -98,8 +101,8 @@ public class OrderFixture {
 
     // 주문 승인 유효성 검사를 위한 DTO
     public static final OrderForOrderApproveValidationDto orderForOrderApproveValidationDto = OrderForOrderApproveValidationDto.builder()
-                                                                                                        .realOrderQuantity(3)
-                                                                                                        .totalPaymentAmount(15000)
+                                                                                                        .realOrderQuantity(ORDER_QUANTITY)
+                                                                                                        .totalPaymentAmount(AMOUNT)
                                                                                                         .outOfStockHandlingOption(OutOfStockHandlingOption.ALL_CANCEL)
                                                                                                         .dealProductUuid(TypeConversionUtils.convertUuidToBinary(UUID.randomUUID()))
                                                                                                         .build();

--- a/src/test/java/com/hcommerce/heecommerce/order/OrderControllerTest.java
+++ b/src/test/java/com/hcommerce/heecommerce/order/OrderControllerTest.java
@@ -196,7 +196,7 @@ class OrderControllerTest {
                 ResultActions resultActions = mockMvc.perform(
                     post("/orders/place-in-advance")
                         .accept(MediaType.APPLICATION_JSON)
-                        .header("Authorization", AuthFixture.AUTHORIZATION).header("Authorization", AuthFixture.AUTHORIZATION)
+                        .header("Authorization", AuthFixture.AUTHORIZATION)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(content)
                 );
@@ -229,7 +229,7 @@ class OrderControllerTest {
                     ResultActions resultActions = mockMvc.perform(
                         post("/orders/place-in-advance")
                             .accept(MediaType.APPLICATION_JSON)
-                        .header("Authorization", AuthFixture.AUTHORIZATION)
+                            .header("Authorization", AuthFixture.AUTHORIZATION)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(content)
                     );
@@ -270,33 +270,6 @@ class OrderControllerTest {
             }
         }
 
-        @Nested
-        @DisplayName("when Invalid inventory decrease occurs")
-        class Context_With_Invalid_Inventory_Decrease_Occurs {
-            @Test
-            @DisplayName("returns 409 error")
-            void It_Returns_409_Error() throws Exception {
-                // given
-                given(orderService.placeOrderInAdvance(any())).willThrow(OrderOverStockException.class);
-
-                OrderFormDto orderFormDto = OrderFixture.ORDER_FORM_DTO;
-
-                String content = objectMapper.writeValueAsString(orderFormDto);
-
-                // when
-                ResultActions resultActions = mockMvc.perform(
-                    post("/orders/place-in-advance")
-                        .accept(MediaType.APPLICATION_JSON)
-                        .header("Authorization", AuthFixture.AUTHORIZATION)
-                        .header("Authorization", AuthFixture.AUTHORIZATION)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content)
-                );
-
-                // then
-                resultActions.andExpect(status().isConflict());
-            }
-        }
     }
 
     @Nested
@@ -339,7 +312,6 @@ class OrderControllerTest {
                 // given
                 given(orderService.approveOrder(any())).willThrow(InvalidPaymentAmountException.class);
 
-
                 // when
                 OrderApproveForm orderApproveForm = OrderFixture.orderApproveForm;
 
@@ -355,6 +327,33 @@ class OrderControllerTest {
 
                 // then
                 resultActions.andExpect(status().isBadRequest());
+            }
+        }
+
+        @Nested
+        @DisplayName("with invalid realOrderQuantity")
+        class Context_With_Invalid_RealOrderQuantity {
+            @Test
+            @DisplayName("returns 400 error")
+            void It_Returns_400_error() throws Exception {
+                // given
+                given(orderService.approveOrder(any())).willThrow(OrderOverStockException.class);
+
+                // when
+                OrderApproveForm orderApproveForm = OrderFixture.orderApproveForm;
+
+                String content = objectMapper.writeValueAsString(orderApproveForm);
+
+                ResultActions resultActions = mockMvc.perform(
+                    post("/orders/approve")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", AuthFixture.AUTHORIZATION)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                );
+
+                // then
+                resultActions.andExpect(status().isConflict());
             }
         }
     }


### PR DESCRIPTION
# Why
- 재고가 없는 상황에서 주문이 이루어질 경우를 대비해서 미리 차감하고, 주문 완료가 이루어지지 않을 경우 재고를 원상복귀하는 방법을 맨처음에는 선택했다.
- 그런데, 이렇게 될 경우, 주문 완료가 이루어지지 않는 상황에 케이스가 너무나도 많고, 그 모든 상황을 고려해서 코드를 작성하면 복잡도가 올라가는 문제가 발생했다.
- 그러면, 다른 방법으로, 배치 형식으로 몇분마다 주문 테이블을 스캔하여 주문 승인이 이루어 지지 않은 경우, 일괄 rollback을 해주는 방법을 생각했었다.
- 그런데, 초기 10분이 주문이 몰리는 상황에서 최대한 주문을 받아야 하는데, 완전히 유효하지 않은 주문 때문에 사용자가 주문하지 못하는 상황이 발생하면, 비즈니스적으로 손해라고 생각해서, 이러한 재고 관리는 적절하지 않다고 생각했다.
- 또한, 기존 방식은 `재고가 없는 상황에서 주문이 이루어지는 케이스`를 대비한 것인데, 이 케이스가 발생할 경우의수는 딜상품의 종류 갯수만큼만 발생할 수 있다고 생각해서,   좀더 단순한 구조로 가기 위해 한 복잡도가 상승하기 떄문에, 

# What
## 변경 전
<img width="994" alt="스크린샷 2023-08-24 오후 4 59 03" src="https://github.com/f-lab-edu/hee-commerce/assets/60481383/c2d1d77b-763f-41b6-bd3a-950777c20e26">

## 변경 후
<img width="994" alt="스크린샷 2023-08-24 오후 4 59 17" src="https://github.com/f-lab-edu/hee-commerce/assets/60481383/be5bd763-9f2e-4f55-aa56-0bc31ebf0fbc">
